### PR TITLE
Map structured data for copyright status

### DIFF
--- a/src/flickypedia/apis/structured_data.py
+++ b/src/flickypedia/apis/structured_data.py
@@ -6,7 +6,25 @@ The goal of this file is to create some helpers and templates to reduce
 the amount of repetition required when creating these entities.
 """
 
-from flickypedia.apis.wikidata import lookup_flickr_user_in_wikidata, WikidataProperties
+from flickypedia.apis.wikidata import (
+    lookup_flickr_user_in_wikidata,
+    WikidataEntities,
+    WikidataProperties,
+)
+
+
+def _link_to_wikibase_entity(*, property, wikidata_id):
+    return {
+        "mainsnak": {
+            "snaktype": "value",
+            "property": property,
+            "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {"id": wikidata_id},
+            },
+        },
+        "type": "statement",
+    }
 
 
 def create_flickr_creator_data(user_id, username, realname):
@@ -22,17 +40,9 @@ def create_flickr_creator_data(user_id, username, realname):
     wikidata_id = lookup_flickr_user_in_wikidata(id=user_id, username=username)
 
     if wikidata_id is not None:
-        return {
-            "mainsnak": {
-                "snaktype": "value",
-                "property": WikidataProperties.CREATOR,
-                "datavalue": {
-                    "type": "wikibase-entityid",
-                    "value": {"id": wikidata_id},
-                },
-            },
-            "type": "statement",
-        }
+        return _link_to_wikibase_entity(
+            property=WikidataProperties.CREATOR, wikidata_id=wikidata_id
+        )
     else:
         qualifier_values = [
             (WikidataProperties.AUTHOR_NAME, realname or username),
@@ -64,3 +74,21 @@ def create_flickr_creator_data(user_id, username, realname):
             ],
             "type": "statement",
         }
+
+
+def create_copyright_status_data(status):
+    """
+    Create a structured data claim for a copyright status.
+
+    Currently this only supports "Copyright status: copyrighted", but
+    it might evolve in future if we e.g. support "no known copyright status".
+    """
+    if status != "copyrighted":
+        raise ValueError(
+            f"Unable to map a copyright status which isn't “copyrighted”: {status!r}"
+        )
+
+    return _link_to_wikibase_entity(
+        property=WikidataProperties.COPYRIGHT_STATUS,
+        wikidata_id=WikidataEntities.Copyrighted,
+    )

--- a/src/flickypedia/apis/wikidata.py
+++ b/src/flickypedia/apis/wikidata.py
@@ -16,6 +16,15 @@ class WikidataProperties:
     AUTHOR_NAME = "P2093"
     FLICKR_USER_ID = "P3267"
     URL = "P2699"
+    COPYRIGHT_STATUS = "P6216"
+
+
+class WikidataEntities:
+    """
+    Named constants for certain Wikidata entities.
+    """
+
+    Copyrighted = "Q50423863"
 
 
 def lookup_flickr_user_in_wikidata(*, id, username):

--- a/tests/apis/test_structured_data.py
+++ b/tests/apis/test_structured_data.py
@@ -2,7 +2,10 @@ import json
 
 import pytest
 
-from flickypedia.apis.structured_data import create_flickr_creator_data
+from flickypedia.apis.structured_data import (
+    create_copyright_status_data,
+    create_flickr_creator_data,
+)
 
 
 @pytest.mark.parametrize(
@@ -28,6 +31,24 @@ from flickypedia.apis.structured_data import create_flickr_creator_data
 )
 def test_create_flickr_creator_data(vcr_cassette, kwargs, filename):
     result = create_flickr_creator_data(**kwargs)
+    expected = json.load(open(f"tests/fixtures/structured_data/{filename}"))
+
+    assert result == expected
+
+
+def test_create_copyright_status_data_fails_for_unknown_value():
+    with pytest.raises(ValueError, match="Unable to map a copyright status"):
+        create_copyright_status_data(status="No known copyright status")
+
+
+@pytest.mark.parametrize(
+    ["kwargs", "filename"],
+    [
+        ({"status": "copyrighted"}, "copyright_status_copyrighted.json"),
+    ],
+)
+def test_create_copyright_status_data(kwargs, filename):
+    result = create_copyright_status_data(**kwargs)
     expected = json.load(open(f"tests/fixtures/structured_data/{filename}"))
 
     assert result == expected

--- a/tests/fixtures/structured_data/copyright_status_copyrighted.json
+++ b/tests/fixtures/structured_data/copyright_status_copyrighted.json
@@ -1,0 +1,13 @@
+{
+  "mainsnak": {
+    "snaktype": "value",
+    "property": "P6216",
+    "datavalue": {
+      "type": "wikibase-entityid",
+      "value": {
+        "id": "Q50423863"
+      }
+    }
+  },
+  "type": "statement"
+}


### PR DESCRIPTION
The next part of https://github.com/Flickr-Foundation/flickypedia/issues/13

Right now it only supports "Copyright status: copyrighted" but we could extend it to support e.g. "No known copyright restrictions" later.