### PR TITLE
Add a warning about missing config

### DIFF
--- a/src/flickypedia/cli.py
+++ b/src/flickypedia/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 
 def main():
@@ -17,5 +18,11 @@ def main():
 
     with app.app_context():
         db.create_all()
+
+    if app.config["OAUTH2_PROVIDERS"]["wikimedia"]["client_id"] is None:
+        sys.exit("No Wikimedia client ID provided! Set WIKIMEDIA_CLIENT_ID.")
+
+    if app.config["OAUTH2_PROVIDERS"]["wikimedia"]["client_secret"] is None:
+        sys.exit("No Wikimedia client secret provided! Set WIKIMEDIA_CLIENT_SECRET.")
 
     app.run(debug=args.debug, port=args.port, host=args.host)


### PR DESCRIPTION
You can invoke Flickypedia by running `flickypedia`, but it will fail when you go to log in if you don't have your Wikimedia OAuth 2.0 credentials.

Normally I invoke Flickypedia by running a short bash wrapper that retrieves my credentials from my system keychain:

```bash
#!/usr/bin/env bash

set -o errexit
set -o nounset

export WIKIMEDIA_CLIENT_ID=$(keyring get wiki_s client_id)
export WIKIMEDIA_CLIENT_SECRET=$(keyring get wiki_s client_secret)
flickypedia --debug
```

But whenever I start the day, I forget the wrapper exists and try running `flickypedia`. This prevents the app starting if you don't set these credentials, so I don't have to wait until I try to log in to get the issue.