### PR TITLE
Rename the variable `jpeg_url` to `original_url`

### DIFF
--- a/src/flickypedia/apis/structured_data.py
+++ b/src/flickypedia/apis/structured_data.py
@@ -156,7 +156,7 @@ def create_copyright_status_statement(status):
     }
 
 
-def create_source_data_for_photo(user_id, photo_id, jpeg_url):
+def create_source_data_for_photo(user_id, photo_id, original_url):
     """
     Create a structured data statement for a Flickr photo.
 
@@ -172,7 +172,7 @@ def create_source_data_for_photo(user_id, photo_id, jpeg_url):
             "value": f"https://www.flickr.com/photos/{user_id}/{photo_id}/",
         },
         {"property": WikidataProperties.Operator, "entity_id": WikidataEntities.Flickr},
-        {"property": WikidataProperties.Url, "value": jpeg_url},
+        {"property": WikidataProperties.Url, "value": original_url},
     ]
 
     return {
@@ -299,7 +299,7 @@ def create_sdc_claims_for_flickr_photo(
     photo_id: str,
     user: FlickrUser,
     copyright_status: str,
-    jpeg_url: str,
+    original_url: str,
     license_id: str,
     date_posted: datetime.datetime,
     date_taken: DateTaken,
@@ -314,7 +314,7 @@ def create_sdc_claims_for_flickr_photo(
     copyright_statement = create_copyright_status_statement(status=copyright_status)
 
     source_statement = create_source_data_for_photo(
-        user_id=user["id"], photo_id=photo_id, jpeg_url=jpeg_url
+        user_id=user["id"], photo_id=photo_id, original_url=original_url
     )
 
     license_statement = create_license_statement(license_id=license_id)

--- a/src/flickypedia/apis/wikimedia.py
+++ b/src/flickypedia/apis/wikimedia.py
@@ -77,7 +77,7 @@ class WikimediaApi:
 
         return resp["query"]["userinfo"]
 
-    def upload_image(self, *, filename, jpeg_url, text):
+    def upload_image(self, *, filename: str, original_url: str, text: str):
         """
         Upload an image to Wikimedia Commons.  Returns the upload filename.
 
@@ -88,7 +88,7 @@ class WikimediaApi:
             data={
                 "action": "upload",
                 "filename": filename,
-                "url": jpeg_url,
+                "url": original_url,
                 "text": text,
             },
             # Note: this can fail with an httpx.ReadTimeout error with

--- a/src/flickypedia/uploads.py
+++ b/src/flickypedia/uploads.py
@@ -15,7 +15,7 @@ def upload_single_image(
     date_taken: DateTaken,
     date_posted: datetime.datetime,
     license_id: str,
-    jpeg_url: str,
+    original_url: str,
 ):
     """
     Upload a photo from Flickr to Wikimedia Commons.
@@ -40,13 +40,13 @@ def upload_single_image(
         photo_id=photo_id,
         user=user,
         copyright_status="copyrighted",
-        jpeg_url=jpeg_url,
+        original_url=original_url,
         license_id=license_id,
         date_posted=date_posted,
         date_taken=date_taken,
     )
 
-    api.upload_image(filename=filename, jpeg_url=jpeg_url, text=wikitext)
+    api.upload_image(filename=filename, original_url=original_url, text=wikitext)
 
     api.add_file_caption(filename=filename, language="en", value=file_caption)
 

--- a/tests/apis/test_structured_data.py
+++ b/tests/apis/test_structured_data.py
@@ -70,7 +70,7 @@ def test_create_source_data_for_photo():
     result = create_source_data_for_photo(
         user_id="199246608@N02",
         photo_id="53248015596",
-        jpeg_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",
+        original_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",
     )
     expected = get_fixture("photo_source_data.json")
 
@@ -145,7 +145,7 @@ def test_create_sdc_claims_for_flickr_photo_without_date_taken(vcr_cassette):
             "realname": "Alex Chan",
         },
         copyright_status="copyrighted",
-        jpeg_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",
+        original_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",
         license_id="cc-by-2.0",
         date_posted=datetime.datetime.fromtimestamp(1696939706),
         date_taken={
@@ -170,7 +170,7 @@ def test_create_sdc_claims_for_flickr_photo_with_date_taken(vcr_cassette):
             "realname": "Maryland GovPics",
         },
         copyright_status="copyrighted",
-        jpeg_url="https://live.staticflickr.com/65535/53234140350_93579322a9_o_d.jpg",
+        original_url="https://live.staticflickr.com/65535/53234140350_93579322a9_o_d.jpg",
         license_id="cc-by-2.0",
         date_posted=datetime.datetime.fromtimestamp(1696421915),
         date_taken={

--- a/tests/apis/test_wikimedia.py
+++ b/tests/apis/test_wikimedia.py
@@ -65,7 +65,7 @@ class TestUploadImage:
 
         resp = wikimedia_api.upload_image(
             filename="Silver Blue Fish In Boston Aquarium.jpg",
-            jpeg_url="https://live.staticflickr.com/8338/8273352482_50cb58a54f_o_d.jpg",
+            original_url="https://live.staticflickr.com/8338/8273352482_50cb58a54f_o_d.jpg",
             text=text,
         )
 
@@ -78,7 +78,7 @@ class TestUploadImage:
         ):
             wikimedia_api.upload_image(
                 filename="example.jpg",
-                jpeg_url="https://alexwlchan.net/images/example.jpg",
+                original_url="https://alexwlchan.net/images/example.jpg",
                 text="An image which doesn’t even exist",
             )
 
@@ -89,7 +89,7 @@ class TestUploadImage:
         ):
             wikimedia_api.upload_image(
                 filename="example.jpg",
-                jpeg_url="https://flickr.com/doesntexist.jpg",
+                original_url="https://flickr.com/doesntexist.jpg",
                 text="An image which doesn’t even exist",
             )
 
@@ -97,7 +97,7 @@ class TestUploadImage:
         with pytest.raises(DuplicateFilenameUploadException) as exc:
             wikimedia_api.upload_image(
                 filename="RailwayMuseumClocks.jpg",
-                jpeg_url="https://live.staticflickr.com/65535/53248279408_c23cba9eb8_o_d.jpg",
+                original_url="https://live.staticflickr.com/65535/53248279408_c23cba9eb8_o_d.jpg",
                 text="A wall of railway pendulum clocks at the Slovenian Railway Museum in Ljubljana",
             )
 
@@ -107,7 +107,7 @@ class TestUploadImage:
         with pytest.raises(DuplicatePhotoUploadException) as exc:
             wikimedia_api.upload_image(
                 filename="Yellow fish at Houston Zoo aquarium.jpg",
-                jpeg_url="https://live.staticflickr.com/6192/6054362864_a8f52ef695_o_d.jpg",
+                original_url="https://live.staticflickr.com/6192/6054362864_a8f52ef695_o_d.jpg",
                 text="A yellow fish",
             )
 

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -17,5 +17,5 @@ def test_upload_single_image(wikimedia_api):
         },
         date_posted=datetime.datetime.fromtimestamp(1697645772),
         license_id="cc-by-2.0",
-        jpeg_url="https://live.staticflickr.com/65535/53268016608_5b890124fd_o_d.jpg",
+        original_url="https://live.staticflickr.com/65535/53268016608_5b890124fd_o_d.jpg",
     )


### PR DESCRIPTION
It's unlikely (if somewhat unusual) to see Flickr images with different formats in their original format.