### PR TITLE
Let's try running with warnings-as-errors after all

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 filterwarnings =
+  error
+
   # This hides a deprecation warning in flask_login:
   #
   #     flask_login/utils.py:130: DeprecationWarning: 'werkzeug.urls.url_encode'
@@ -13,3 +15,17 @@ filterwarnings =
   # When we upgrade to a version of flask-login that includes
   # this fix (>0.6.2), we can remove this filter.
   ignore::DeprecationWarning:flask_login*:
+  
+  # This hides a deprecation warnings in python-dateutil on Python 3.12:
+  #
+  #     DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated
+  #     and scheduled for removal in a future version. Use timezone-aware objects
+  #     to represent datetimes in UTC:
+  #     datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
+  #
+  # There's a fix for this in python-dateutil, but there's no new version yet:
+  # https://github.com/dateutil/dateutil/issues/1284
+  #
+  # When we upgrade to a version of python-dateutil that includes
+  # this fix (>2.8.2), we can remove this filter.
+  ignore::DeprecationWarning:dateutil*:

--- a/src/flickypedia/apis/flickr.py
+++ b/src/flickypedia/apis/flickr.py
@@ -271,10 +271,12 @@ class ResourceNotFound(FlickrApiException):
 def _parse_date_posted(p):
     # See https://www.flickr.com/services/api/misc.dates.html
     # e.g. '1490376472'
-    return datetime.datetime.utcfromtimestamp(int(p))
+    return datetime.datetime.fromtimestamp(int(p), tz=datetime.timezone.utc)
 
 
 def _parse_date_taken(p):
     # See https://www.flickr.com/services/api/misc.dates.html
     # e.g. '2017-02-17 00:00:00'
-    return datetime.datetime.strptime(p, "%Y-%m-%d %H:%M:%S")
+    return datetime.datetime.strptime(p, "%Y-%m-%d %H:%M:%S").replace(
+        tzinfo=datetime.timezone.utc
+    )

--- a/tests/apis/test_flickr.py
+++ b/tests/apis/test_flickr.py
@@ -146,7 +146,9 @@ class TestGetSinglePhoto:
         info = flickr_api.get_single_photo(photo_id="5240741057")
 
         assert info["date_taken"] == {
-            "value": datetime.datetime(1950, 1, 1, 0, 0, 0),
+            "value": datetime.datetime(
+                1950, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+            ),
             "granularity": 6,
             "unknown": False,
         }
@@ -155,7 +157,9 @@ class TestGetSinglePhoto:
         info = flickr_api.get_single_photo(photo_id="25868667441")
 
         assert info["date_taken"] == {
-            "value": datetime.datetime(2016, 3, 21, 16, 15, 39),
+            "value": datetime.datetime(
+                2016, 3, 21, 16, 15, 39, tzinfo=datetime.timezone.utc
+            ),
             "granularity": 0,
             "unknown": True,
         }

--- a/tests/fixtures/flickr_api/32812033543.json
+++ b/tests/fixtures/flickr_api/32812033543.json
@@ -5,9 +5,9 @@
     "username": "U.S. Coast Guard",
     "realname": "Coast Guard"
   },
-  "date_posted": "2017-03-24T17:27:52",
+  "date_posted": "2017-03-24T17:27:52+00:00",
   "date_taken": {
-    "value": "2017-02-17T00:00:00",
+    "value": "2017-02-17T00:00:00+00:00",
     "granularity": 0,
     "unknown": false
   },


### PR DESCRIPTION
Seconds after saying "we can't do this" (see #54) I realised I could do it, and I think it's a good practice if we can.

As a nice bonus – we know the dates from the Flickr API are GMT/UTC, and now that's stored in the datetime objects.