### PR TITLE
If a user enters a bad URL, preserve it on the error page

### DIFF
--- a/src/flickypedia/pages/find_photos.py
+++ b/src/flickypedia/pages/find_photos.py
@@ -13,14 +13,19 @@ def find_photos():
     if form.validate_on_submit():
         url = form.flickr_url.data
 
+        # Try to parse this as a Flickr URL.  If parsing fails for
+        # some reason, return the user to the page.
+        #
+        # Make sure the input field still contains the URL they typed in,
+        # so they can adjust what they typed previously.
         try:
             parse_flickr_url(url)
         except NotAFlickrUrl:
             flash("That URL doesn’t live on Flickr.com", category="flickr_url")
-            return render_template("find_photos.html", form=form)
+            return render_template("find_photos.html", form=form, flickr_url=url)
         except UnrecognisedUrl:
             flash("There are no photos to show at that URL", category="flickr_url")
-            return render_template("find_photos.html", form=form)
+            return render_template("find_photos.html", form=form, flickr_url=url)
 
         return redirect(url_for("select_photos", flickr_url=url))
 

--- a/tests/pages/test_find_photos.py
+++ b/tests/pages/test_find_photos.py
@@ -14,6 +14,7 @@ def test_rejects_a_non_flickr_url(logged_in_client):
 
     assert b"Enter a Flickr URL" in resp.data
     assert "That URL doesn’t live on Flickr.com" in resp.data.decode("utf8")
+    assert b'value="https://example.net"' in resp.data
 
 
 def test_rejects_a_non_photo_flickr_url(logged_in_client):
@@ -25,6 +26,7 @@ def test_rejects_a_non_photo_flickr_url(logged_in_client):
 
     assert b"Enter a Flickr URL" in resp.data
     assert b"There are no photos to show at that URL" in resp.data
+    assert b'value="https://flickr.com/help"' in resp.data
 
 
 def test_redirects_if_photo_url(logged_in_client):


### PR DESCRIPTION
Previously typing in a URL which was rejected because:

* it wasn't on flickr.com, e.g. example.net, or
* it wasn't a photo page, e.g. flickr.com/help

would be rejected and clear the input field.  This is annoying, because the user can't fix their input or even see what they typed!

Passing the `flickr_url` variable to the template ensures the problem URL is still shown on the page when they get the error.

Closes https://github.com/Flickr-Foundation/flickypedia/issues/68