### PR TITLE
Don't duplicate our structured data in the Wikitext

### DIFF
--- a/src/flickypedia/apis/wikitext.py
+++ b/src/flickypedia/apis/wikitext.py
@@ -1,6 +1,10 @@
 """
 Create Wikitext for display on Wikimedia Commons.
 
+Note that we primarily rely on structured data to put information on
+the page using the Lua-driven {{Information}} template, so we don't
+need to put in much text ourself.
+
 == Useful reading ==
 
 *   Help:Wikitext
@@ -8,50 +12,17 @@ Create Wikitext for display on Wikimedia Commons.
 
 """
 
-from flickypedia.apis.flickr import DateTaken, FlickrUser, TakenDateGranularity
 
-
-def create_wikitext(
-    photo_url: str, date_taken: DateTaken, user: FlickrUser, license_id: str
-) -> str:
+def create_wikitext(license_id: str) -> str:
     """
     Creates the Wikitext for a Flickr photo being uploaded to Wiki Commons.
     """
-    # The date is formatted with varying degrees of granularity.
-    #
-    # For dates which are circa or unknown from the Flickr API, we use
-    # two Wikimedia templates for rendering this sort of data.
-    #
-    # See https://commons.wikimedia.org/wiki/Template:Circa
-    # See https://commons.wikimedia.org/wiki/Template:Unknown
-    #
-    date_format_string = {
-        TakenDateGranularity.Second: "%Y-%m-%d %H:%M:%S",
-        TakenDateGranularity.Month: "%Y-%m",
-        TakenDateGranularity.Year: "%Y",
-        TakenDateGranularity.Circa: "{{circa|%Y}}",
-    }[date_taken["granularity"]]
-
-    if date_taken["unknown"]:
-        date_string = "{{Other date|?}}"
-    else:
-        date_string = date_taken["value"].strftime(date_format_string)
 
     return """=={{int:filedesc}}==
-{{Information
-|Source=%s
-|Date=%s
-|Author=[https://www.flickr.com/people/%s %s]
-|Permission=
-|other_versions=
-}}
+{{Information}}
 
 =={{int:license-header}}==
 {{%s}}
 """ % (
-        photo_url,
-        date_string,
-        user["id"],
-        user["realname"] or user["username"],
         license_id,
     )

--- a/src/flickypedia/uploads.py
+++ b/src/flickypedia/uploads.py
@@ -27,14 +27,7 @@ def upload_single_image(
     -   Adding the structured data to the photo
 
     """
-    photo_url = f"https://www.flickr.com/photos/{user['id']}/{photo_id}/"
-
-    wikitext = create_wikitext(
-        photo_url=photo_url,
-        date_taken=date_taken,
-        user=user,
-        license_id=license_id,
-    )
+    wikitext = create_wikitext(license_id=license_id)
 
     structured_data = create_sdc_claims_for_flickr_photo(
         photo_id=photo_id,

--- a/tests/apis/test_wikimedia.py
+++ b/tests/apis/test_wikimedia.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 
 from flickypedia.apis.structured_data import create_license_statement
@@ -48,20 +46,7 @@ def test_can_get_a_csrf_token(wikimedia_api):
 
 class TestUploadImage:
     def test_can_upload_an_image(self, wikimedia_api):
-        text = create_wikitext(
-            photo_url="https://www.flickr.com/photos/pictureclara/8273352482/",
-            date_taken={
-                "value": datetime.datetime(2012, 12, 8, 15, 8, 45),
-                "granularity": 0,
-                "unknown": False,
-            },
-            user={
-                "id": "13151547@N06",
-                "username": "Clara S.",
-                "realname": None,
-            },
-            license_id="cc-by-2.0",
-        )
+        text = create_wikitext(license_id="cc-by-2.0")
 
         resp = wikimedia_api.upload_image(
             filename="Silver Blue Fish In Boston Aquarium.jpg",

--- a/tests/apis/test_wikitext.py
+++ b/tests/apis/test_wikitext.py
@@ -1,128 +1,15 @@
-import datetime
-
-import pytest
-
 from flickypedia.apis.wikitext import create_wikitext
 
 
-def test_create_wikitext_for_regular_photo():
+def test_create_wikitext_for_photo():
     actual = create_wikitext(
-        photo_url="https://www.flickr.com/photos/199246608@N02/53255367525/",
-        date_taken={
-            "value": datetime.datetime(2023, 10, 11, 11, 49, 25),
-            "unknown": False,
-            "granularity": 0,
-        },
-        user={
-            "id": "199246608@N02",
-            "username": "cefarrjf87",
-            "realname": "Alex Chan",
-        },
         license_id="cc-by-2.0",
     )
     expected = """=={{int:filedesc}}==
-{{Information
-|Source=https://www.flickr.com/photos/199246608@N02/53255367525/
-|Date=2023-10-11 11:49:25
-|Author=[https://www.flickr.com/people/199246608@N02 Alex Chan]
-|Permission=
-|other_versions=
-}}
+{{Information}}
 
 =={{int:license-header}}==
 {{cc-by-2.0}}
 """
 
     assert actual == expected
-
-
-@pytest.mark.parametrize(
-    ["date_taken", "expected_date_text"],
-    [
-        (
-            {
-                "value": datetime.datetime(2001, 2, 3, 4, 5, 6),
-                "unknown": False,
-                "granularity": 0,  # Day
-            },
-            "|Date=2001-02-03 04:05:06\n",
-        ),
-        (
-            {
-                "value": datetime.datetime(2001, 2, 3, 4, 5, 6),
-                "unknown": False,
-                "granularity": 4,  # Month
-            },
-            "|Date=2001-02\n",
-        ),
-        (
-            {
-                "value": datetime.datetime(2001, 2, 3, 4, 5, 6),
-                "unknown": False,
-                "granularity": 6,  # Year
-            },
-            "|Date=2001\n",
-        ),
-        (
-            {
-                "value": datetime.datetime(2001, 2, 3, 4, 5, 6),
-                "unknown": False,
-                "granularity": 8,  # Circa
-            },
-            "|Date={{circa|2001}}\n",
-        ),
-        (
-            {
-                "value": datetime.datetime(2001, 2, 3, 4, 5, 6),
-                "unknown": True,
-                "granularity": 0,  # Circa
-            },
-            "|Date={{Other date|?}}\n",
-        ),
-    ],
-)
-def test_create_wikitext_with_date_granularity(date_taken, expected_date_text):
-    wikitext = create_wikitext(
-        photo_url="https://www.flickr.com/photos/example/1234",
-        date_taken=date_taken,
-        user={"id": "1234", "username": "example", "realname": "example"},
-        license_id="cc-by-2.0",
-    )
-
-    assert expected_date_text in wikitext
-
-
-@pytest.mark.parametrize(
-    ["user", "expected_author_text"],
-    [
-        (
-            {
-                "id": "199246608@N02",
-                "username": "cefarrjf87",
-                "realname": "Alex Chan",
-            },
-            "|Author=[https://www.flickr.com/people/199246608@N02 Alex Chan]",
-        ),
-        (
-            {
-                "id": "35591378@N03",
-                "username": "Obama White House Archived",
-                "realname": None,
-            },
-            "|Author=[https://www.flickr.com/people/35591378@N03 Obama White House Archived]",
-        ),
-    ],
-)
-def test_create_wikitext_with_user_info(user, expected_author_text):
-    wikitext = create_wikitext(
-        photo_url="https://www.flickr.com/photos/example/1234",
-        date_taken={
-            "value": datetime.datetime(2001, 2, 3, 4, 5, 6),
-            "unknown": False,
-            "granularity": 0,
-        },
-        user=user,
-        license_id="cc-by-2.0",
-    )
-
-    assert expected_author_text in wikitext

--- a/tests/fixtures/cassettes/test_can_upload_an_image.yml
+++ b/tests/fixtures/cassettes/test_can_upload_an_image.yml
@@ -63,7 +63,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: action=upload&filename=Silver+Blue+Fish+In+Boston+Aquarium.jpg&url=https%3A%2F%2Flive.staticflickr.com%2F8338%2F8273352482_50cb58a54f_o_d.jpg&text=%3D%3D%7B%7Bint%3Afiledesc%7D%7D%3D%3D%0A%7B%7BInformation%0A%7CSource%3Dhttps%3A%2F%2Fwww.flickr.com%2Fphotos%2Fpictureclara%2F8273352482%2F%0A%7CDate%3D2012-12-08+15%3A08%3A45%0A%7CAuthor%3D%5Bhttps%3A%2F%2Fwww.flickr.com%2Fpeople%2F13151547%40N06+Clara+S.%5D%0A%7CPermission%3D%0A%7Cother_versions%3D%0A%7D%7D%0A%0A%3D%3D%7B%7Bint%3Alicense-header%7D%7D%3D%3D%0A%7B%7Bcc-by-2.0%7D%7D%0A&format=json&token=9259b755e0401716925708666a90948d652ff65d%2B%5C
+    body: action=upload&filename=Silver+Blue+Fish+In+Boston+Aquarium.jpg&url=https%3A%2F%2Flive.staticflickr.com%2F8338%2F8273352482_50cb58a54f_o_d.jpg&text=%3D%3D%7B%7Bint%3Afiledesc%7D%7D%3D%3D%0A%7B%7BInformation%7D%7D%0A%0A%3D%3D%7B%7Bint%3Alicense-header%7D%7D%3D%3D%0A%7B%7Bcc-by-2.0%7D%7D%0A&format=json&token=9259b755e0401716925708666a90948d652ff65d%2B%5C
     headers:
       accept:
       - '*/*'
@@ -72,7 +72,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '601'
+      - '353'
       content-type:
       - application/x-www-form-urlencoded
       cookie:


### PR DESCRIPTION
We can use the Lua-driven {{Information}} template, which fills this in automatically from the structured data, saving us from having to copy it in ourselves.

Closes https://github.com/Flickr-Foundation/flickypedia/issues/60