### PR TITLE
Make the working directory configurable

### DIFF
--- a/src/flickypedia/__init__.py
+++ b/src/flickypedia/__init__.py
@@ -15,16 +15,19 @@ from flickypedia.apis.wikidata import (
     get_property_name,
     render_wikidata_date,
 )
-from flickypedia.config import Config, get_directories
+from flickypedia.config import create_config, get_directories
 from flickypedia.duplicates import create_link_to_commons
 from flickypedia.views import find_photos, homepage, prepare_info, select_photos
 from flickypedia.tasks import celery_init_app
 from flickypedia.utils import a_href, size_at
 
 
-def create_app():
+def create_app(data_directory):
     app = Flask(__name__)
-    app.config.from_object(Config)
+
+    config = create_config(data_directory)
+
+    app.config.update(**config)
 
     db.init_app(app)
     login.init_app(app)

--- a/src/flickypedia/cli.py
+++ b/src/flickypedia/cli.py
@@ -16,7 +16,7 @@ def main():
 
     from flickypedia import create_app
 
-    app = create_app()
+    app = create_app(data_directory="data")
 
     if app.config["OAUTH2_PROVIDERS"]["wikimedia"]["client_id"] is None:
         sys.exit("No Wikimedia client ID provided! Set WIKIMEDIA_CLIENT_ID.")

--- a/src/flickypedia/config.py
+++ b/src/flickypedia/config.py
@@ -1,57 +1,28 @@
 import os
 
 
-# Flickypedia writes a number of temporary files as part of
-# its process.  This directory is the root for all of those files.
-WORKING_DATA_DIRECTORY = "data"
+def create_config(data_directory):
+    """
+    Create the config for Flickypedia.
 
+    Flickypedia writes a number of temporary files as part of its work.
+    The ``data_directory`` is their root.
+    """
+    celery_directory = os.path.join(data_directory, "celery")
 
-class Config(object):
-    SECRET_KEY = os.environ.get("SECRET_KEY") or "you-will-never-guess"
-
-    FLICKR_API_KEY = os.environ.get("FLICKR_API_KEY", "<UNKNOWN>")
-
-    SQLALCHEMY_DATABASE_URI = "sqlite:///db.sqlite"
-
-    # Used as a temporary cache for responses from the Flickr API.
-    #
-    # We can save results in here, and pass the filename around in the
-    # user session.  This is just public data from the Flickr API,
-    # so there's nothing sensitive in here.
-    FLICKR_API_RESPONSE_CACHE = os.path.join(WORKING_DATA_DIRECTORY, "flickr_api_cache")
-
-    # Used as a directory to find SQLite databases which contain information
-    # about duplicates.
-    DUPLICATE_DATABASE_DIRECTORY = os.path.join(WORKING_DATA_DIRECTORY, "duplicates")
-
-    OAUTH2_PROVIDERS = {
-        # Implementation note: although these URLs are currently hard-coded,
-        # there is a beta cluster we might use in the future.  It's currently
-        # broken, so we're not adding support for it yet, but we could if
-        # it ever gets fixed.
-        #
-        # See https://github.com/Flickr-Foundation/flickypedia/issues/4
-        "wikimedia": {
-            "client_id": os.environ.get("WIKIMEDIA_CLIENT_ID"),
-            "client_secret": os.environ.get("WIKIMEDIA_CLIENT_SECRET"),
-            "authorize_url": "https://meta.wikimedia.org/w/rest.php/oauth2/authorize",
-            "token_url": "https://meta.wikimedia.org/w/rest.php/oauth2/access_token",
-        }
-    }
-
-    CELERY = {
-        "result_backend": f"file://{WORKING_DATA_DIRECTORY}/celery/results",
+    celery_config = {
+        "result_backend": f"file://{celery_directory}/results",
         "broker_url": "filesystem://",
         "broker_transport_options": {
-            "data_folder_in": f"{WORKING_DATA_DIRECTORY}/celery/queue",
-            "data_folder_out": f"{WORKING_DATA_DIRECTORY}/celery/queue",
-            "processed_folder": f"{WORKING_DATA_DIRECTORY}/celery/processed",
+            "data_folder_in": os.path.join(celery_directory, "queue"),
+            "data_folder_out": os.path.join(celery_directory, "queue"),
+            "processed_folder": os.path.join(celery_directory, "processed"),
             #
             # This isn't a Celery config option, but it's used by
             # Celery in our app for tracking in-progress work.
             #
             # We store it here for convenience.
-            "in_progress_folder": f"{WORKING_DATA_DIRECTORY}/celery/in_progress_folder",
+            "in_progress_folder": os.path.join(celery_directory, "in_progress_folder"),
             #
             # The processed tasks include the original arguments passed
             # to Celery, which has the user's OAuth credentials in
@@ -60,14 +31,46 @@ class Config(object):
         },
     }
 
-    # The IDs of licenses that we can upload to Flickypedia.
-    ALLOWED_LICENSES = {"cc-by-2.0", "cc-by-sa-2.0", "usgov", "cc0-1.0", "pdm"}
-
-    # The number of photos to show on a single page
-    PHOTOS_PER_PAGE = 100
-
-    # A User-Agent sent on HTTP requests
-    USER_AGENT = "Flickypedia/0.1 (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)"
+    return {
+        "SECRET_KEY": os.environ.get("SECRET_KEY") or "you-will-never-guess",
+        "FLICKR_API_KEY": os.environ.get("FLICKR_API_KEY", "<UNKNOWN>"),
+        "SQLALCHEMY_DATABASE_URI": f"sqlite:///{data_directory}/db.sqlite",
+        #
+        # Used as a temporary cache for responses from the Flickr API.
+        #
+        # We can save results in here, and pass the filename around in the
+        # user session.  This is just public data from the Flickr API,
+        # so there's nothing sensitive in here.
+        "FLICKR_API_RESPONSE_CACHE": os.path.join(data_directory, "flickr_api_cache"),
+        #
+        # Used as a directory to find SQLite databases which contain information
+        # about duplicates.
+        "DUPLICATE_DATABASE_DIRECTORY": os.path.join(data_directory, "duplicates"),
+        "OAUTH2_PROVIDERS": {
+            # Implementation note: although these URLs are currently hard-coded,
+            # there is a beta cluster we might use in the future.  It's currently
+            # broken, so we're not adding support for it yet, but we could if
+            # it ever gets fixed.
+            #
+            # See https://github.com/Flickr-Foundation/flickypedia/issues/4
+            "wikimedia": {
+                "client_id": os.environ.get("WIKIMEDIA_CLIENT_ID"),
+                "client_secret": os.environ.get("WIKIMEDIA_CLIENT_SECRET"),
+                "authorize_url": "https://meta.wikimedia.org/w/rest.php/oauth2/authorize",
+                "token_url": "https://meta.wikimedia.org/w/rest.php/oauth2/access_token",
+            }
+        },
+        "CELERY": celery_config,
+        #
+        # The IDs of licenses that we can upload to Flickypedia.
+        "ALLOWED_LICENSES": {"cc-by-2.0", "cc-by-sa-2.0", "usgov", "cc0-1.0", "pdm"},
+        #
+        # The number of photos to show on a single page
+        "PHOTOS_PER_PAGE": 100,
+        #
+        # A User-Agent sent on HTTP requests
+        "USER_AGENT": "Flickypedia/0.1 (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)",
+    }
 
 
 def get_directories(config):

--- a/src/flickypedia/tasks.py
+++ b/src/flickypedia/tasks.py
@@ -34,9 +34,7 @@ import time
 import celery
 from celery import Celery, shared_task
 from celery.result import AsyncResult
-from flask import Flask
-
-from flickypedia.config import Config
+from flask import Flask, current_app
 
 
 def celery_init_app(app: Flask) -> Celery:
@@ -64,7 +62,7 @@ class ProgressTracker:
         Returns the path to a file which can be used for tracking information
         about an in-progress task.
         """
-        config = Config().CELERY
+        config = current_app.config["CELERY"]
         in_progress_folder = config["broker_transport_options"]["in_progress_folder"]
 
         return os.path.join(in_progress_folder, f"{self.task_id}.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from flask_login import FlaskLoginClient
 import pytest
@@ -88,16 +89,24 @@ def flickr_api(cassette_name, user_agent):
 
 
 @pytest.fixture()
-def app(user_agent):
+def app(user_agent, tmpdir):
     """
     Creates an instance of the app for use in testing.
 
     See https://flask.palletsprojects.com/en/3.0.x/testing/#fixtures
     """
-    app = create_app()
+    app = create_app(data_directory=tmpdir)
     app.config["TESTING"] = True
 
-    app.config["DUPLICATE_DATABASE_DIRECTORY"] = "tests/fixtures/duplicates"
+    app.config["DUPLICATE_DATABASE_DIRECTORY"] = os.path.join(tmpdir, "duplicates")
+    shutil.copyfile(
+        "tests/fixtures/duplicates/flickr_ids_from_sdc_for_testing.sqlite",
+        os.path.join(
+            app.config["DUPLICATE_DATABASE_DIRECTORY"],
+            "flickr_ids_from_sdc_for_testing.sqlite",
+        ),
+    )
+
     app.config["PHOTOS_PER_PAGE"] = 10
 
     app.config["USER_AGENT"] = user_agent

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7,7 +7,7 @@ from flickypedia.tasks import ProgressTracker
 
 
 @pytest.fixture
-def tracker():
+def tracker(app):
     t = ProgressTracker(task_id=str(uuid.uuid4()))
     yield t
 

--- a/tests/views/test_find_photos.py
+++ b/tests/views/test_find_photos.py
@@ -44,7 +44,7 @@ def test_redirects_if_photo_url(logged_in_client):
     assert resp.headers["location"] == f"/select_photos?flickr_url={flickr_url}"
 
 
-def test_preserves_photo_if_csrf_bad():
+def test_preserves_photo_if_csrf_bad(tmpdir):
     """
     If the user submits the form after their CSRF token expires, we
     don't lose the URL they've typed in.
@@ -56,7 +56,7 @@ def test_preserves_photo_if_csrf_bad():
     # We have to create the app object manually, rather than using the
     # fixtures provided in ``conftest.py`` -- they disable CSRF for
     # ease of testing, but in this case we need CSRF to replicate the bug.
-    app = create_app()
+    app = create_app(data_directory=tmpdir)
     app.config["TESTING"] = True
 
     app.config["WTF_CSRF_ENABLED"] = True


### PR DESCRIPTION
This allows us to use a temporary directory in tests, which will be useful for testing uploads, where we want to mutate duplicate DB state and have it cleaned up afterwards.