### PR TITLE
Tweak the fallback for 'photo size not found'

### DIFF
--- a/src/flickypedia/utils.py
+++ b/src/flickypedia/utils.py
@@ -40,19 +40,24 @@ def size_at(sizes, *, desired_size):
     """
     sizes_by_label = {s["label"]: s for s in sizes}
 
-    # If we have that exact size available, return that!
-    if desired_size in sizes_by_label:
-        return sizes_by_label[desired_size]
-
     # Flickr has a published list of possible sizes here:
     # https://www.flickr.com/services/api/misc.urls.html
     #
-    # If the desired size isn't available, we can look for alternatives,
-    # but this fallback code is deliberately conservative and simple.
-    # We're trying to build something that works for Flickypedia,
-    # not any combination of Flickr sizes/desired size.
-    if desired_size == "Medium" and "Small" in sizes_by_label:
-        return sizes_by_label["Small"]
+    # If the desired size isn't available, that means one of two things:
+    #
+    #   1.  The owner of this photo has done something to restrict downloads
+    #       of their photo beyond a certain size.  But CC-licensed photos
+    #       are always available to download, so that's not an issue for us.
+    #   2.  This photo is smaller than the size we've asked for, in which
+    #       case we fall back to Original as the largest possible size.
+    #
+    try:
+        return sizes_by_label[desired_size]
+    except KeyError:
+        return sizes_by_label["Original"]
+
+    if desired_size == "Medium":
+        return sizes_by_label["Original"]
 
     raise ValueError(f"This photo is not available at size {desired_size!r}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import datetime
 import json
 
 from cryptography.fernet import Fernet
-import pytest
 
 from flickypedia.utils import (
     decrypt_string,
@@ -46,19 +45,22 @@ SIZES = sizes = [
         "url": "https://www.flickr.com/photos/coast_guard/32812033543/sizes/s/",
         "media": "photo",
     },
+    {
+        "label": "Original",
+        "width": 5172,
+        "height": 3145,
+        "source": "https://live.staticflickr.com/2903/32812033543_41cc4e453a_o.jpg",
+        "url": "https://www.flickr.com/photos/coast_guard/32812033543/sizes/o/",
+        "media": "photo",
+    },
 ]
 
 
 def test_size_at_finds_desired_size():
-    assert size_at(SIZES, desired_size="Small") == SIZES[-1]
+    assert size_at(SIZES, desired_size="Small") == SIZES[-2]
 
 
-def test_size_at_fails_if_no_desired_size():
-    with pytest.raises(ValueError, match="This photo is not available at size 'Large'"):
-        size_at(SIZES, desired_size="Large")
-
-
-def test_size_at_will_get_small_if_medium_unavailable():
+def test_size_at_falls_back_to_original_if_desired_size_unavailable():
     assert size_at(SIZES, desired_size="Medium") == SIZES[-1]
 
 


### PR DESCRIPTION
This should squash any errors caused by our code complaining that it can't find the size it needs.

Longer term, it might be nice to do away with picking sizes entirely and just render an `<img>` with an `srcset` attribute, and let the browser choose.