### PR TITLE
Require Wikimedia auth for the validate_title() method

### DIFF
--- a/src/flickypedia/apis/wikimedia.py
+++ b/src/flickypedia/apis/wikimedia.py
@@ -297,136 +297,125 @@ class WikimediaApi:
         else:  # pragma: no cover
             raise WikimediaApiException(f"Unexpected response: {resp}")
 
+    def validate_title(self, title: str):
+        """
+        Given the name of a title, check whether it's allowed as
+        a title for a new file on Wikimedia Commons.
 
-class WikimediaPublicApi(WikimediaApi):
-    def __init__(self):
-        client = httpx.Client(
-            base_url="https://commons.wikimedia.org", headers={"User-Agent": "testing"}
-        )
-        super().__init__(client=client)
+        We try to rely on the Wikimedia APIs to do this for us, rather
+        than duplicating their logic -- it's slower, but it saves us
+        from having to maintain our own copy of the logic (which would
+        inevitably be slightly wrong or broken).
 
+        Instead, we do similar checks to the File Upload Wizard.
+        I opened the Upload Wizard in my browser, then I used the
+        developer tools to observe the API requests going back and
+        forth to check whether the title was okay.
 
-def validate_title(title: str):
-    """
-    Given the name of a title, check whether it's allowed as
-    a title for a new file on Wikimedia Commons.
+        The current result from this function is always a dict like:
 
-    We try to rely on the Wikimedia APIs to do this for us, rather
-    than duplicating their logic -- it's slower, but it saves us
-    from having to maintain our own copy of the logic (which would
-    inevitably be slightly wrong or broken).
+            {'result': 'duplicate|blacklisted|invalid|ok|…'}
 
-    Instead, we do similar checks to the File Upload Wizard.
-    I opened the Upload Wizard in my browser, then I used the
-    developer tools to observe the API requests going back and
-    forth to check whether the title was okay.
+        The theory is that at some point we might add additional keys
+        to this dictionary, e.g. with more detailed error information.
 
-    The current result from this function is always a dict like:
+        """
+        assert title.startswith("File:")
 
-        {'result': 'duplicate|blacklisted|invalid|ok|…'}
+        # There's a maximum length of 240 bytes for UTF-8 encoded filenames
+        # in Wikimedia Commons.
+        #
+        # See https://commons.wikimedia.org/wiki/Commons:File_naming#Length
+        length_in_bytes = len(title.encode("utf8"))
 
-    The theory is that at some point we might add additional keys
-    to this dictionary, e.g. with more detailed error information.
-
-    """
-    api = WikimediaPublicApi()
-
-    assert title.startswith("File:")
-
-    # There's a maximum length of 240 bytes for UTF-8 encoded filenames
-    # in Wikimedia Commons.
-    #
-    # See https://commons.wikimedia.org/wiki/Commons:File_naming#Length
-    length_in_bytes = len(title.encode("utf8"))
-
-    if length_in_bytes > 240:
-        return {
-            "result": "too_long",
-            "text": "This title is too long. Please choose a title which is less than 240 bytes.",
-        }
-
-    # Check for other pages with this title -- are we going to
-    # duplicate an existing file?
-    #
-    # If the file exists, we'll get the ID of the existing page in
-    # the `pages` list in the response:
-    #
-    #     {"query": {"pages": {"139632053": {…}}}}
-    #
-    # If the file doesn't exist, we'll get "-1" as the ID:
-    #
-    #     {"query": {"pages": {"-1": {…}}}}
-    #
-    existing_title_resp = api._get(
-        params={"action": "query", "titles": title, "prop": "info"}
-    )
-
-    if existing_title_resp["query"]["pages"].keys() != {"-1"}:
-        return {
-            "result": "duplicate",
-            "text": (
-                "Please choose a different title. "
-                f"There is already <a href='https://commons.wikimedia.org/wiki/{title}'>a file on Commons</a> with that title."
-            ),
-        }
-
-    # Second check to see if the title is blocked.
-    #
-    # This could be if e.g. the title is too long, or too short, or
-    # contains forbidden characters.
-    #
-    # If the title is blacklisted, we'll get a response like:
-    #
-    #     {
-    #       "titleblacklist": {
-    #         "result": "blacklisted",
-    #         "reason":"<p>The file name you were trying to upload
-    #                   has been [[c:MediaWiki:Titleblacklist|blacklisted]]
-    #                   because it is very common, uninformative, or
-    #                   spelled in ALLCAPS.
-    #       …
-    #     }
-    #
-    # If the title is invalid, we'll get a response like:
-    #
-    #     {
-    #       "error": {
-    #         "code": "invalidtitle",
-    #         "info":"Bad title \"File:\".",
-    #         …
-    #     }
-    #
-    # If the title is allowed, we'll get a response:
-    #
-    #     {"titleblacklist":{"result":"ok"}}
-    #
-    # See https://www.mediawiki.org/wiki/Extension:TitleBlacklist#Testing_for_matches
-    # See https://www.mediawiki.org/w/api.php?action=help&modules=titleblacklist
-    #
-    try:
-        blacklist_resp = api._get(
-            params={
-                "action": "titleblacklist",
-                "tbaction": "create",
-                "tbtitle": title,
-            }
-        )
-    except UnknownWikimediaApiException as exc:
-        if exc.code == "invalidtitle":
+        if length_in_bytes > 240:
             return {
-                "result": "invalid",
+                "result": "too_long",
+                "text": "This title is too long. Please choose a title which is less than 240 bytes.",
+            }
+
+        # Check for other pages with this title -- are we going to
+        # duplicate an existing file?
+        #
+        # If the file exists, we'll get the ID of the existing page in
+        # the `pages` list in the response:
+        #
+        #     {"query": {"pages": {"139632053": {…}}}}
+        #
+        # If the file doesn't exist, we'll get "-1" as the ID:
+        #
+        #     {"query": {"pages": {"-1": {…}}}}
+        #
+        existing_title_resp = self._get(
+            params={"action": "query", "titles": title, "prop": "info"}
+        )
+
+        if existing_title_resp["query"]["pages"].keys() != {"-1"}:
+            return {
+                "result": "duplicate",
+                "text": (
+                    "Please choose a different title. "
+                    f"There is already <a href='https://commons.wikimedia.org/wiki/{title}'>a file on Commons</a> with that title."
+                ),
+            }
+
+        # Second check to see if the title is blocked.
+        #
+        # This could be if e.g. the title is too long, or too short, or
+        # contains forbidden characters.
+        #
+        # If the title is blacklisted, we'll get a response like:
+        #
+        #     {
+        #       "titleblacklist": {
+        #         "result": "blacklisted",
+        #         "reason":"<p>The file name you were trying to upload
+        #                   has been [[c:MediaWiki:Titleblacklist|blacklisted]]
+        #                   because it is very common, uninformative, or
+        #                   spelled in ALLCAPS.
+        #       …
+        #     }
+        #
+        # If the title is invalid, we'll get a response like:
+        #
+        #     {
+        #       "error": {
+        #         "code": "invalidtitle",
+        #         "info":"Bad title \"File:\".",
+        #         …
+        #     }
+        #
+        # If the title is allowed, we'll get a response:
+        #
+        #     {"titleblacklist":{"result":"ok"}}
+        #
+        # See https://www.mediawiki.org/wiki/Extension:TitleBlacklist#Testing_for_matches
+        # See https://www.mediawiki.org/w/api.php?action=help&modules=titleblacklist
+        #
+        try:
+            blacklist_resp = self._get(
+                params={
+                    "action": "titleblacklist",
+                    "tbaction": "create",
+                    "tbtitle": title,
+                }
+            )
+        except UnknownWikimediaApiException as exc:
+            if exc.code == "invalidtitle":
+                return {
+                    "result": "invalid",
+                    "text": "Please choose a different, more descriptive title.",
+                }
+            else:  # pragma: no cover
+                raise
+
+        if blacklist_resp["titleblacklist"]["result"] != "ok":
+            return {
+                "result": "blacklisted",
                 "text": "Please choose a different, more descriptive title.",
             }
-        else:  # pragma: no cover
-            raise
 
-    if blacklist_resp["titleblacklist"]["result"] != "ok":
-        return {
-            "result": "blacklisted",
-            "text": "Please choose a different, more descriptive title.",
-        }
-
-    return {"result": "ok"}
+        return {"result": "ok"}
 
 
 class WikimediaApiException(Exception):

--- a/src/flickypedia/views/__init__.py
+++ b/src/flickypedia/views/__init__.py
@@ -1,7 +1,6 @@
 from flask import abort, render_template, request, jsonify
-from flask_login import login_required
+from flask_login import current_user, login_required
 
-from flickypedia.apis.wikimedia import validate_title
 from .get_photos import get_photos
 from .prepare_info import prepare_info, truncate_description
 from .select_photos import select_photos
@@ -33,7 +32,10 @@ def validate_title_api():
     except KeyError:
         return abort(400)
 
-    return jsonify(validate_title(title))
+    api = current_user.wikimedia_api()
+    result = api.validate_title(title)
+
+    return jsonify(result)
 
 
 __all__ = [

--- a/src/flickypedia/views/prepare_info.py
+++ b/src/flickypedia/views/prepare_info.py
@@ -21,7 +21,6 @@ from wtforms.validators import DataRequired, Length, ValidationError
 from wtforms.widgets import TextArea
 
 from flickypedia.apis.structured_data import create_sdc_claims_for_flickr_photo
-from flickypedia.apis.wikimedia import validate_title
 from flickypedia.uploads import upload_batch_of_photos
 from flickypedia.utils import size_at
 from .select_photos import get_cached_api_response, remove_cached_api_response
@@ -52,7 +51,8 @@ class WikiFieldsForm(Form):
     def validate_title(form, field):
         title = f"File:{field.data}.{form.original_format}"
 
-        validation = validate_title(title=title)
+        api = current_user.wikimedia_api()
+        validation = api.validate_title(title=title)
 
         if validation["result"] != "ok":
             raise ValidationError(validation["text"])

--- a/tests/apis/test_wikimedia.py
+++ b/tests/apis/test_wikimedia.py
@@ -8,7 +8,6 @@ from flickypedia.apis.wikimedia import (
     DuplicatePhotoUploadException,
     InvalidAccessTokenException,
     UnknownWikimediaApiException,
-    validate_title,
 )
 from flickypedia.apis.wikitext import create_wikitext
 
@@ -236,12 +235,12 @@ class TestAddStructuredData:
         pytest.param("File:FishingBoatsByTheRiver.jpg", "ok", id="allowed_title"),
     ],
 )
-def test_validate_title(vcr_cassette, title, result):
-    assert validate_title(title=title)["result"] == result
+def test_validate_title(wikimedia_api, title, result):
+    assert wikimedia_api.validate_title(title=title)["result"] == result
 
 
-def test_validate_title_links_to_duplicates(vcr_cassette):
-    result = validate_title(title="File:P1.jpg")
+def test_validate_title_links_to_duplicates(wikimedia_api):
+    result = wikimedia_api.validate_title(title="File:P1.jpg")
 
     assert (
         result["text"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,15 @@ def test_homepage_shows_user_info_if_logged_in(logged_in_client):
     assert "you’re logged in as" in resp.data.decode("utf8")
 
 
-@pytest.mark.parametrize("path", ["/logout", "/get_photos", "/select_photos"])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/logout",
+        "/get_photos",
+        "/select_photos",
+        "/api/validate_title?title=MyGreatPhoto",
+    ],
+)
 def test_redirected_to_homepage_for_pages_requiring_login(client, path):
     resp = client.get(path)
     assert resp.status_code == 302


### PR DESCRIPTION
This should avoid us hitting [rate limits](https://api.wikimedia.org/wiki/Rate_limits#:~:text=API%20requests%20authenticated%20using%20a,to%205%2C000%20requests%20per%20hour.) on this method, because now all our title validation requests are segmented per-user.

This is extracted from #160.