### PR TITLE
Fix the way we describe the copyright status of PD images

### DIFF
--- a/src/flickypedia/structured_data/structured_data.py
+++ b/src/flickypedia/structured_data/structured_data.py
@@ -22,6 +22,9 @@ is supporting that function.
 *   Commons:Flickypedia/Data Modeling
     https://commons.wikimedia.org/wiki/Commons:Flickypedia/Data_Modeling
 
+*   Commons:Structured data/Modeling
+    https://commons.wikimedia.org/wiki/Commons:Structured_data/Modeling
+
 """
 
 import datetime
@@ -139,17 +142,25 @@ def create_copyright_status_statement(license_id: str) -> NewStatement:
             ],
             "type": "statement",
         }
+
+    # See https://commons.wikimedia.org/wiki/Commons:Structured_data/Modeling/Copyright#Copyrighted,_dedicated_to_the_public_domain_by_copyright_holder
     elif license_id in {"cc0-1.0", "pdm"}:
         return {
             "mainsnak": {
                 "snaktype": "value",
                 "property": WikidataProperties.CopyrightStatus,
                 "datavalue": to_wikidata_entity_value(
-                    entity_id=WikidataEntities.PublicDomain
+                    entity_id=WikidataEntities.DedicatedToPublicDomainByCopyrightOwner
                 ),
             },
             "type": "statement",
         }
+
+    # We don't map all licenses in this function -- just the licenses
+    # which are accepted on Wikimedia Commons.
+    #
+    # In theory we should never be creating SDC for photos which can't
+    # be shared on WMC; this is to give a helpful error if we do.
     else:
         raise ValueError(f"Unable to map a copyright status for license {license_id!r}")
 

--- a/src/flickypedia/structured_data/wikidata.py
+++ b/src/flickypedia/structured_data/wikidata.py
@@ -47,6 +47,7 @@ class WikidataEntities:
     # e.g. https://www.wikidata.org/wiki/Q103204
     Circa = "Q5727902"
     Copyrighted = "Q50423863"
+    DedicatedToPublicDomainByCopyrightOwner = "Q88088423"
     FileAvailableOnInternet = "Q74228490"
     Flickr = "Q103204"
     GregorianCalendar = "Q1985727"

--- a/tests/fixtures/structured_data/copyright_status_public_domain.json
+++ b/tests/fixtures/structured_data/copyright_status_public_domain.json
@@ -3,8 +3,8 @@
     "datavalue": {
       "type": "wikibase-entityid",
       "value": {
-        "id": "Q19652",
-        "numeric-id": 19652,
+        "id": "Q88088423",
+        "numeric-id": 88088423,
         "entity-type": "item"
       }
     },


### PR DESCRIPTION
I was reading https://commons.wikimedia.org/wiki/Commons:Structured_data/Modeling/Copyright and realised I'd mapped this slightly wrong.