### PR TITLE
Record when a user first logs in to the app

### DIFF
--- a/src/flickypedia/auth.py
+++ b/src/flickypedia/auth.py
@@ -66,6 +66,7 @@ it should be accessing it via ``current_user``.
 
 """
 
+import datetime
 import json
 from typing import Optional
 import uuid
@@ -112,6 +113,7 @@ class WikimediaUserSession(UserMixin, user_db.Model):  # type: ignore
     userid = user_db.Column(user_db.Integer, nullable=False)
     name = user_db.Column(user_db.String(64), nullable=False)
     encrypted_token = user_db.Column(user_db.LargeBinary, nullable=False)
+    first_login = user_db.Column(user_db.DateTime, nullable=False)
 
     def get_id(self) -> str:
         """
@@ -366,6 +368,7 @@ def oauth2_callback_wikimedia() -> ViewResponse:
         userid=userinfo["id"],
         name=userinfo["name"],
         encrypted_token=encrypt_string(key, plaintext=json.dumps(token)),
+        first_login=datetime.datetime.now(),
     )
     user_db.session.add(user)
     user_db.session.commit()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import re
@@ -52,6 +53,7 @@ def store_user(token: OAuth2Token) -> WikimediaUserSession:
         userid="-1",
         name="example",
         encrypted_token=encrypt_string(key, plaintext=json.dumps(token)),
+        first_login=datetime.datetime.now(),
     )
     user_db.session.add(user)
     user_db.session.commit()


### PR DESCRIPTION
Because database entries are per-session rather than per-user, this will allow us to purge old sessions from the database later.

Closes #168.