### PR TITLE
Remove the "stated by copyright holder" qualifier for now

### DIFF
--- a/src/flickypedia/structured_data/structured_data.py
+++ b/src/flickypedia/structured_data/structured_data.py
@@ -225,24 +225,12 @@ def create_license_statement(license_id: str) -> NewStatement:
     except KeyError:
         raise ValueError(f"Unrecognised license ID: {license_id!r}")
 
-    qualifier_values: List[QualifierValues] = [
-        {
-            "property": WikidataProperties.DeterminationMethod,
-            "entity_id": WikidataEntities.StatedByCopyrightHolderAtSourceWebsite,
-            "type": "entity",
-        },
-    ]
-
     return {
         "mainsnak": {
             "snaktype": "value",
             "property": WikidataProperties.CopyrightLicense,
             "datavalue": to_wikidata_entity_value(entity_id=wikidata_license_id),
         },
-        "qualifiers": create_qualifiers(qualifier_values),
-        "qualifiers-order": [
-            WikidataProperties.DeterminationMethod,
-        ],
         "type": "statement",
     }
 

--- a/tests/fixtures/structured_data/license_cc0.json
+++ b/tests/fixtures/structured_data/license_cc0.json
@@ -11,24 +11,5 @@
       "type": "wikibase-entityid"
     }
   },
-  "qualifiers": {
-    "P459": [
-      {
-        "datavalue": {
-          "type": "wikibase-entityid",
-          "value": {
-            "id": "Q61045577",
-            "numeric-id": 61045577,
-            "entity-type": "item"
-          }
-        },
-        "property": "P459",
-        "snaktype": "value"
-      }
-    ]
-  },
-  "qualifiers-order": [
-    "P459"
-  ],
   "type": "statement"
 }

--- a/tests/fixtures/structured_data/license_cc_by_2.0.json
+++ b/tests/fixtures/structured_data/license_cc_by_2.0.json
@@ -11,24 +11,5 @@
       "type": "wikibase-entityid"
     }
   },
-  "qualifiers": {
-    "P459": [
-      {
-        "datavalue": {
-          "type": "wikibase-entityid",
-          "value": {
-            "id": "Q61045577",
-            "numeric-id": 61045577,
-            "entity-type": "item"
-          }
-        },
-        "property": "P459",
-        "snaktype": "value"
-      }
-    ]
-  },
-  "qualifiers-order": [
-    "P459"
-  ],
   "type": "statement"
 }

--- a/tests/fixtures/structured_data/license_usgov.json
+++ b/tests/fixtures/structured_data/license_usgov.json
@@ -11,24 +11,5 @@
       "type": "wikibase-entityid"
     }
   },
-  "qualifiers": {
-    "P459": [
-      {
-        "datavalue": {
-          "type": "wikibase-entityid",
-          "value": {
-            "id": "Q61045577",
-            "numeric-id": 61045577,
-            "entity-type": "item"
-          }
-        },
-        "property": "P459",
-        "snaktype": "value"
-      }
-    ]
-  },
-  "qualifiers-order": [
-    "P459"
-  ],
   "type": "statement"
 }

--- a/tests/fixtures/structured_data/photo_53234140350.json
+++ b/tests/fixtures/structured_data/photo_53234140350.json
@@ -128,25 +128,6 @@
           "type": "wikibase-entityid"
         }
       },
-      "qualifiers": {
-        "P459": [
-          {
-            "datavalue": {
-              "type": "wikibase-entityid",
-              "value": {
-                "id": "Q61045577",
-                "numeric-id": 61045577,
-                "entity-type": "item"
-              }
-            },
-            "property": "P459",
-            "snaktype": "value"
-          }
-        ]
-      },
-      "qualifiers-order": [
-        "P459"
-      ],
       "type": "statement"
     },
     {

--- a/tests/fixtures/structured_data/photo_53248015596.json
+++ b/tests/fixtures/structured_data/photo_53248015596.json
@@ -157,25 +157,6 @@
           "type": "wikibase-entityid"
         }
       },
-      "qualifiers": {
-        "P459": [
-          {
-            "datavalue": {
-              "type": "wikibase-entityid",
-              "value": {
-                "id": "Q61045577",
-                "numeric-id": 61045577,
-                "entity-type": "item"
-              }
-            },
-            "property": "P459",
-            "snaktype": "value"
-          }
-        ]
-      },
-      "qualifiers-order": [
-        "P459"
-      ],
       "type": "statement"
     },
     {

--- a/tests/templates/prepare_info/test_structured_data_preview.py
+++ b/tests/templates/prepare_info/test_structured_data_preview.py
@@ -198,11 +198,6 @@ def test_shows_license_statement(app: Flask, vcr_cassette: str) -> None:
           <dt>copyright license:</dt>
           <dd class="snak-value">
             Creative Commons Attribution 2.0 Generic (Q19125117)
-            <ul class="sdc_qualifiers plain_list">
-             <li>
-              determination method: stated by copyright holder at source website (Q61045577)
-             </li>
-            </ul>
           </dd>
         </dl>
         """


### PR DESCRIPTION
It was stated by a user on Flickr.com, but they may not be the copyright holder for this photo!

Closes https://github.com/Flickr-Foundation/flickypedia/issues/224