### PR TITLE
Use the `tmp_path` fixture, not `tmpdir`

### DIFF
--- a/src/flickypedia/cli.py
+++ b/src/flickypedia/cli.py
@@ -1,3 +1,4 @@
+import pathlib
 import sys
 
 import click
@@ -23,7 +24,7 @@ def main() -> None:  # pragma: no cover
 def run_dev_server(port: int, host: str, debug: bool) -> None:
     from flickypedia.uploadr import create_app
 
-    app = create_app(data_directory="data", debug=debug)
+    app = create_app(data_directory=pathlib.Path("data"), debug=debug)
 
     if app.config["OAUTH2_PROVIDERS"]["wikimedia"]["client_id"] is None:
         sys.exit("No Wikimedia client ID provided! Set WIKIMEDIA_CLIENT_ID.")

--- a/src/flickypedia/uploadr/__init__.py
+++ b/src/flickypedia/uploadr/__init__.py
@@ -1,5 +1,6 @@
 import html
 import os
+import pathlib
 import uuid
 
 from flask import Flask, request
@@ -40,7 +41,9 @@ from .tasks import celery_init_app
 from flickypedia.utils import create_bookmarklet
 
 
-def create_app(data_directory: str = "data", debug: bool = False) -> Flask:
+def create_app(
+    data_directory: pathlib.Path = pathlib.Path("data"), debug: bool = False
+) -> Flask:
     app = Flask(__name__)
 
     config = create_config(data_directory)

--- a/src/flickypedia/uploadr/config.py
+++ b/src/flickypedia/uploadr/config.py
@@ -1,30 +1,31 @@
 import os
+import pathlib
 from typing import Any, Dict, List
 
 
-def create_config(data_directory: str) -> Dict[str, Any]:
+def create_config(data_directory: pathlib.Path) -> Dict[str, Any]:
     """
     Create the config for Flickypedia.
 
     Flickypedia writes a number of temporary files as part of its work.
     The ``data_directory`` is their root.
     """
-    celery_directory = os.path.join(data_directory, "celery")
+    celery_directory = data_directory / "celery"
 
     celery_config = {
         "base_dir": celery_directory,
         "result_backend": f"file://{celery_directory}/results",
         "broker_url": "filesystem://",
         "broker_transport_options": {
-            "data_folder_in": os.path.join(celery_directory, "queue"),
-            "data_folder_out": os.path.join(celery_directory, "queue"),
-            "processed_folder": os.path.join(celery_directory, "processed"),
+            "data_folder_in": celery_directory / "queue",
+            "data_folder_out": celery_directory / "queue",
+            "processed_folder": celery_directory / "processed",
             #
             # This isn't a Celery config option, but it's used by
             # Celery in our app for tracking in-progress work.
             #
             # We store it here for convenience.
-            "in_progress_folder": os.path.join(celery_directory, "in_progress_folder"),
+            "in_progress_folder": celery_directory / "in_progress_folder",
             #
             # The processed tasks include the original arguments passed
             # to Celery, which has the user's OAuth credentials in
@@ -38,18 +39,18 @@ def create_config(data_directory: str) -> Dict[str, Any]:
         "FLICKR_API_KEY": os.environ.get("FLICKR_API_KEY", "<UNKNOWN>"),
         #
         # TODO: Get this into the data directory.
-        "SQLALCHEMY_DATABASE_URI": f"sqlite:///{os.path.abspath(data_directory)}/db.sqlite",
+        "SQLALCHEMY_DATABASE_URI": f"sqlite:///{data_directory.absolute()}/db.sqlite",
         #
         # Used as a temporary cache for responses from the Flickr API.
         #
         # We can save results in here, and pass the filename around in the
         # user session.  This is just public data from the Flickr API,
         # so there's nothing sensitive in here.
-        "FLICKR_API_RESPONSE_CACHE": os.path.join(data_directory, "flickr_api_cache"),
+        "FLICKR_API_RESPONSE_CACHE": data_directory / "flickr_api_cache",
         #
         # Used as a directory to find SQLite databases which contain information
         # about duplicates.
-        "DUPLICATE_DATABASE_DIRECTORY": os.path.join(data_directory, "duplicates"),
+        "DUPLICATE_DATABASE_DIRECTORY": data_directory / "duplicates",
         "OAUTH2_PROVIDERS": {
             # Implementation note: although these URLs are currently hard-coded,
             # there is a beta cluster we might use in the future.  It's currently

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import pathlib
 import shutil
 from typing import Generator
 
@@ -117,16 +118,16 @@ def flickr_api(
 
 
 @pytest.fixture()
-def app(user_agent: str, tmpdir: str) -> Generator[Flask, None, None]:
+def app(user_agent: str, tmp_path: pathlib.Path) -> Generator[Flask, None, None]:
     """
     Creates an instance of the app for use in testing.
 
     See https://flask.palletsprojects.com/en/3.0.x/testing/#fixtures
     """
-    app = create_app(data_directory=tmpdir)
+    app = create_app(data_directory=tmp_path)
     app.config["TESTING"] = True
 
-    app.config["DUPLICATE_DATABASE_DIRECTORY"] = os.path.join(tmpdir, "duplicates")
+    app.config["DUPLICATE_DATABASE_DIRECTORY"] = os.path.join(tmp_path, "duplicates")
     shutil.copyfile(
         "tests/fixtures/duplicates/flickr_ids_from_sdc_for_testing.sqlite",
         os.path.join(

--- a/tests/uploadr/views/test_get_photos.py
+++ b/tests/uploadr/views/test_get_photos.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from flask.testing import FlaskClient
 from flask_login import FlaskLoginClient
 
@@ -45,7 +47,7 @@ def test_redirects_if_photo_url(logged_in_client: FlaskClient) -> None:
     assert resp.headers["location"] == f"/select_photos?flickr_url={flickr_url}"
 
 
-def test_preserves_photo_if_csrf_bad(tmpdir: str) -> None:
+def test_preserves_photo_if_csrf_bad(tmp_path: pathlib.Path) -> None:
     """
     If the user submits the form after their CSRF token expires, we
     don't lose the URL they've typed in.
@@ -57,7 +59,7 @@ def test_preserves_photo_if_csrf_bad(tmpdir: str) -> None:
     # We have to create the app object manually, rather than using the
     # fixtures provided in ``conftest.py`` -- they disable CSRF for
     # ease of testing, but in this case we need CSRF to replicate the bug.
-    app = create_app(data_directory=tmpdir)
+    app = create_app(data_directory=tmp_path)
     app.config["TESTING"] = True
 
     app.config["WTF_CSRF_ENABLED"] = True


### PR DESCRIPTION
I was reading the pytest documentation for the `tmpdir` fixture, and I came across a note [1]:

> These days, it is preferred to use `tmp_path`.

This converts us to use the preferred fixture, and fixes the type of the fixture throughout the codebase.  This means switching to `pathlib.Path()`, which is arguably nicer anyway.

[1]: https://docs.pytest.org/en/latest/reference/reference.html#pytest.legacypath.LegacyTmpdirPlugin.tmpdir