### PR TITLE
Fix issues in the "wait for upload" screen

### DIFF
--- a/src/flickypedia/uploadr/static/flickypedia.js
+++ b/src/flickypedia/uploadr/static/flickypedia.js
@@ -388,13 +388,17 @@ function addInteractiveCategoriesTo(categoriesElement, parentForm) {
  * This function is called once per second on the "wait for upload"
  * screen.  It adds the "Done" or "Not Done" labels to photos.
  *
- * This calls the /status endpoint, which it expects to return a
- * list of entries of the form:
+ * This calls the /status endpoint, which it expects to return an
+ * object of the form:
  *
- *    [
- *      {"photo_id": "1234", "state": "waiting|in_progress|failed|succeeded"},
- *      …,
- *    ]
+ *    {
+ *      "state": "completed|failed|…",
+ *      "photos": [
+ *        {"photo_id": "1234", "state": "waiting|in_progress|failed|succeeded"},
+ *        …,
+ *      ]
+ *    }
+ *
  *
  */
 function updatePhotosWithUploadProgress() {
@@ -404,13 +408,13 @@ function updatePhotosWithUploadProgress() {
       var processingCount = 0;
 
       /* If we're done, redirect the user to the next screen. */
-      if (json.ready) {
+      if (json.state === 'completed' || json.state === 'failed') {
         window.location.href = window.location.href.replace("/wait_for_upload/", "/upload_complete/")
       }
 
-      json.progress.forEach((progress) => {
-        const photoId = progress.req.photo.id;
-        const uploadStatus = progress.status;
+      json.photos.forEach((entry) => {
+        const photoId = entry.photo_id;
+        const uploadStatus = entry.state;
 
         const liElement = document
           .querySelector(`li[data-id="${photoId}"]`);
@@ -443,6 +447,6 @@ function updatePhotosWithUploadProgress() {
 
       document
         .querySelector('.image_counter')
-        .innerHTML = `${processingCount} of ${json.progress.length}`;
+        .innerHTML = `${processingCount} of ${json.photos.length}`;
     });
 }

--- a/src/flickypedia/uploadr/views/wait_for_upload.py
+++ b/src/flickypedia/uploadr/views/wait_for_upload.py
@@ -73,8 +73,11 @@ def get_upload_status(task_id: str) -> ViewResponse:
     task = q.read_task(task_id)
 
     return jsonify(
-        [
-            {"photo_id": photo_id, "state": output["state"]}
-            for photo_id, output in task["task_output"].items()
-        ]
+        {
+            "state": task["state"],
+            "photos": [
+                {"photo_id": photo_id, "state": output["state"]}
+                for photo_id, output in task["task_output"].items()
+            ],
+        }
     )

--- a/tests/uploadr/views/test_wait_for_upload.py
+++ b/tests/uploadr/views/test_wait_for_upload.py
@@ -29,6 +29,7 @@ def test_wait_for_upload_api(logged_in_client: FlaskClient, queue_dir: None) -> 
         "/wait_for_upload/e358876e-f3d6-439b-85fa-1ed1e46338ec/status"
     )
 
-    assert json.loads(resp.data) == [
-        {"photo_id": "53340605524", "state": "in_progress"}
-    ]
+    assert json.loads(resp.data) == {
+        "state": "in_progress",
+        "photos": [{"photo_id": "53340605524", "state": "in_progress"}],
+    }


### PR DESCRIPTION
It was broken on Friday – I’d changed the "wait for upload" API that the JavaScript uses, and apparently updated the documentation for the function … but not the function itself.