### PR TITLE
Add a proper mapping of Flickr licenses to Wikimedia templates

### DIFF
--- a/src/flickypedia/apis/wikitext.py
+++ b/src/flickypedia/apis/wikitext.py
@@ -12,18 +12,32 @@ need to put in much text ourself.
 
 """
 
+# This maps our license IDs into the names of Wikimedia templates.
+LICENSE_TEMPLATE_MAPPING = {
+    # https://commons.wikimedia.org/wiki/Template:Cc-by-2.0
+    "cc-by-2.0": "Cc-by-2.0",
+    # https://commons.wikimedia.org/wiki/Template:Cc-by-sa-2.0
+    "cc-by-sa-2.0": "Cc-by-sa-2.0",
+    # https://en.wikipedia.org/wiki/Template:CC0
+    "cc0-1.0": "CC0",
+    "pdm": "CC0",
+    # https://commons.wikimedia.org/wiki/Template:PD-USGov
+    "usgov": "PD-USGov",
+}
+
 
 def create_wikitext(license_id: str) -> str:
     """
     Creates the Wikitext for a Flickr photo being uploaded to Wiki Commons.
     """
+    license_template_name = LICENSE_TEMPLATE_MAPPING[license_id]
 
     lines = [
         "=={{int:filedesc}}==",
         "{{Information}}",
         "",
         "=={{int:license-header}}==",
-        "{{%s}}" % license_id,
+        "{{%s}}" % license_template_name,
     ]
 
     return "\n".join(lines)

--- a/tests/apis/test_wikitext.py
+++ b/tests/apis/test_wikitext.py
@@ -1,4 +1,9 @@
+import pathlib
+
+import pytest
+
 from flickypedia.apis.wikitext import create_wikitext
+from flickypedia.uploadr.config import create_config
 
 
 def test_create_wikitext_for_photo() -> None:
@@ -7,6 +12,14 @@ def test_create_wikitext_for_photo() -> None:
 {{Information}}
 
 =={{int:license-header}}==
-{{cc-by-2.0}}"""
+{{Cc-by-2.0}}"""
 
     assert actual == expected
+
+
+config = create_config(data_directory=pathlib.Path("data"))
+
+
+@pytest.mark.parametrize("license_id", config["ALLOWED_LICENSES"])
+def test_can_create_wikitext_for_all_allowed_licenses(license_id: str) -> None:
+    create_wikitext(license_id=license_id)


### PR DESCRIPTION
The license ID and template names happen to match for the CC-BY licenses I was testing with, but they aren't the same for any other license types -- this ensures they'll show up in the Wikitext correctly.

Fixes #260.