### PR TITLE
Discard photos with `accuracy="0"` sooner

### DIFF
--- a/src/flickypedia/apis/structured_data/structured_data.py
+++ b/src/flickypedia/apis/structured_data/structured_data.py
@@ -234,7 +234,7 @@ def create_license_statement(license_id: str) -> NewStatement:
     }
 
 
-def create_location_statement(location: LocationInfo | None) -> NewStatement | None:
+def create_location_statement(location: LocationInfo) -> NewStatement:
     """
     Creates a structured data statement for the "coordinates of
     the point of view" statement.
@@ -245,9 +245,6 @@ def create_location_statement(location: LocationInfo | None) -> NewStatement | N
 
     See https://flickrfoundation.slack.com/archives/C05AVC1JYL9/p1696947242703349
     """
-    if location is None:
-        return None
-
     # The accuracy parameter in the Flickr API response tells us
     # the precision of the location information (15 November 2023):
     #
@@ -255,15 +252,6 @@ def create_location_statement(location: LocationInfo | None) -> NewStatement | N
     #     World level is 1, Country is ~3, Region ~6, City ~11, Street ~16.
     #     Current range is 1-16.
     #
-    # But some photos have an accuracy of 0!  It's unclear what this
-    # means or how we should map this -- lower numbers mean less accurate,
-    # so this location information might be completely useless.
-    #
-    # We prefer to omit information of unknown accuracy, rather than
-    # write bad data into Wikimedia.
-    if location["accuracy"] == 0:
-        return None
-
     # Flickr doesn't publish any definitive stats on how their accuracy
     # levels map to absolute position on the Earth, so I had to make
     # some rough guesses.  This information is already approximate, so
@@ -502,8 +490,7 @@ def create_sdc_claims_for_flickr_photo(
     if photo["date_taken"] is not None:
         statements.append(create_date_taken_statement(date_taken=photo["date_taken"]))
 
-    location_statement = create_location_statement(location=photo["location"])
-    if location_statement is not None:
-        statements.append(location_statement)
+    if photo["location"] is not None:
+        statements.append(create_location_statement(location=photo["location"]))
 
     return {"claims": statements}

--- a/tests/apis/structured_data/test_structured_data.py
+++ b/tests/apis/structured_data/test_structured_data.py
@@ -197,16 +197,6 @@ def test_create_date_taken_statement_fails_on_unrecognised_granularity() -> None
 
 
 class TestCreateLocationStatement:
-    def test_empty_location_is_no_statement(self) -> None:
-        assert create_location_statement(location=None) is None
-
-    def test_accuracy_zero_means_no_statement(self) -> None:
-        statement = create_location_statement(
-            location={"latitude": 8.079310, "longitude": 77.550004, "accuracy": 0}
-        )
-
-        assert statement is None
-
     def test_unrecognised_location_accuracy_is_error(self) -> None:
         with pytest.raises(ValueError, match="Unrecognised location accuracy"):
             create_location_statement(

--- a/tests/fixtures/cassettes/TestCollectionsPhotoResponse.test_discards_location_if_accuracy_zero.yml
+++ b/tests/fixtures/cassettes/TestCollectionsPhotoResponse.test_discards_location_if_accuracy_zero.yml
@@ -1,0 +1,325 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Frudrpeter%2F
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
+      id=\"52568942@N05\">\n\t<username>Rudr Peter | Smile to the world |</username>\n</user>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:19:09 GMT
+      Via:
+      - 1.1 2198d73d723eb37fb611b71c9a3c8382.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - wgunbYZRz5Y2qunG7xq9QLr-tMT-lWXI2b5vJ7CaW6iBVNA9F96g_w==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:19:09 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:19:09 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=52568942%40N05
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"52568942@N05\" nsid=\"52568942@N05\" ispro=\"1\" is_deleted=\"0\" iconserver=\"65535\"
+      iconfarm=\"66\" path_alias=\"rudrpeter\" has_stats=\"0\" pro_badge=\"standard\"
+      expire=\"0\" has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>Rudr
+      Peter | Smile to the world |</username>\n\t<realname>Rudr Peter</realname>\n\t<description>&lt;a
+      href=&quot;http://www.flickriver.com/photos/rudrpeter/popular-interesting/&quot;
+      rel=&quot;noreferrer nofollow&quot;&gt;&lt;img loading=&#039;lazy&#039; class=&#039;notsowide&#039;
+      src=&quot;https://flimg.flickr.com/?url=http%3A%2F%2Fwww.flickriver.com%2Fbadge%2Fuser%2Fall%2Finteresting%2Fshuffle%2Fmedium-horiz%2Fffffff%2F333333%2F52568942%40N05.jpg&amp;h=3e8e8c382d8e483efb27d9de8efa290910c0abd5bc5a2a945c18ff45864095e4&quot;
+      alt=&quot;Rudr Peter - View my most interesting photos on Flickriver&quot; title=&quot;Rudr
+      Peter - View my most interesting photos on Flickriver&quot; /&gt;&lt;/a&gt;</description>\n\t<photosurl>https://www.flickr.com/photos/rudrpeter/</photosurl>\n\t<profileurl>https://www.flickr.com/people/rudrpeter/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=52563602</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2009-06-22
+      21:47:21</firstdatetaken>\n\t\t<firstdate>1282574286</firstdate>\n\t\t<count>1128</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '708'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:19:09 GMT
+      Via:
+      - 1.1 2198d73d723eb37fb611b71c9a3c8382.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - vVL-62yyqHBSQ7q6IZ5jd-BjmNkyuq6Pb8wG_1Pw6esSv7G5FmjdjQ==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:19:09 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Coriginal_format%2Cowner_name%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o%2Ctags%2Cgeo%2Curl_q%2Curl_l%2Cdescription%2Csafety_level%2Crealname&method=flickr.photosets.getPhotos&page=1&per_page=1&photoset_id=72157633859840285&user_id=52568942%40N05
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157633859840285\" primary=\"8914348608\" owner=\"52568942@N05\" ownername=\"Rudr
+      Peter | Smile to the world |\" page=\"1\" per_page=\"1\" perpage=\"1\" pages=\"29\"
+      title=\"India\" total=\"29\">\n\t<photo id=\"8914348608\" secret=\"7519bf916c\"
+      server=\"3736\" farm=\"4\" title=\"Gateway of India\" isprimary=\"0\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"0\" safety_level=\"0\" dateupload=\"1370114405\"
+      datetaken=\"2013-05-24 21:18:25\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Rudr Peter | Smile to the world |\" realname=\"Rudr Peter\" tags=\"india
+      nikon jetty bombay mumbai maharastra viceroy gatewayofindia vicroy britisheastindiacompany
+      britishraj chatrapatishivaji indianhistory d5000 tajmahalpalace rudrpeter britishgovernors
+      stateguests\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/3736/8914348608_7519bf916c_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/3736/8914348608_7519bf916c_t.jpg\"
+      height_t=\"66\" width_t=\"100\" url_s=\"https://live.staticflickr.com/3736/8914348608_7519bf916c_m.jpg\"
+      height_s=\"159\" width_s=\"240\" url_m=\"https://live.staticflickr.com/3736/8914348608_7519bf916c.jpg\"
+      height_m=\"332\" width_m=\"500\" url_q=\"https://live.staticflickr.com/3736/8914348608_7519bf916c_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/3736/8914348608_7519bf916c_b.jpg\"
+      height_l=\"680\" width_l=\"1024\">\n\t\t<description>The Gateway of India is
+      a monument built during the British Raj in Mumbai (formerly Bombay), India.
+      \ It is located on the waterfront in the Apollo Bunder area, South Mumbai and
+      overlooks the Arabian Sea.  The structure is a basalt arch, 26 metres (85 feet)
+      high. It lies at the end of Chhatrapati Shivaji Marg at the water&#039;s edge
+      in Mumbai Harbour.  It was a crude jetty used by the fishing community which
+      was later renovated and used as a landing place for British governors and other
+      prominent people. In earlier times, it would have been the first structure that
+      visitors arriving by boat in Mumbai would have seen.  The Gateway has also been
+      referred to as the Taj Mahal of Mumbai, and is the city&#039;s top tourist attraction.\n\nThe
+      structure was erected to commemorate the landing of their Majesties King George
+      V and Queen Mary at Apollo Bunder, when they visited India in 1911. Built in
+      Indo-Saracenic style, the foundation stone for the Gateway of India was laid
+      on 31 March 1911. The final design of George Wittet was sanctioned in 1914 and
+      the construction of the monument was completed in 1924. The Gateway was later
+      the ceremonial entrance to India for Viceroys and the new Governors of Bombay.
+      \ It served to allow entry and access to India.\n\nThe monument has faced three
+      terror attacks from the beginning of the 21st century; twice in 2003 and it
+      was also the disembarkation point in 2008 when four gunmen attacked the Taj
+      Mahal Palace &amp;amp; Tower.\n\nData Courtesy: &lt;a href=&quot;http://en.wikipedia.org/wiki/Gateway_of_India&quot;
+      rel=&quot;nofollow&quot;&gt;en.wikipedia.org/wiki/Gateway_of_India&lt;/a&gt;</description>\n\t</photo>\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1493'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:19:10 GMT
+      Via:
+      - 1.1 2198d73d723eb37fb611b71c9a3c8382.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - qBvfjR4f0FFF7wXJYW6vPpJDNumhBpVJgej4TrlfO-lkNg5yZ7llqA==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:19:09 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '395'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:19:10 GMT
+      Via:
+      - 1.1 2198d73d723eb37fb611b71c9a3c8382.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gZZoOdEC6LSyLIpcoXYI5oPKFWhE70h17bOfI1lnmaa3Fd3B5KF3ow==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:19:10 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photosets.getInfo&photoset_id=72157633859840285&user_id=52568942%40N05
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157633859840285\" owner=\"52568942@N05\" username=\"Rudr Peter | Smile
+      to the world |\" primary=\"8914348608\" secret=\"7519bf916c\" server=\"3736\"
+      farm=\"4\" count_views=\"12\" count_comments=\"0\" count_photos=\"29\" count_videos=\"0\"
+      can_comment=\"0\" date_create=\"1370114405\" date_update=\"1691999358\" photos=\"29\"
+      visibility_can_see_set=\"1\" needs_interstitial=\"0\">\n\t<title>India</title>\n\t<description
+      />\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '337'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:19:10 GMT
+      Via:
+      - 1.1 2198d73d723eb37fb611b71c9a3c8382.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - M49VTNu3vzFiJ-y4YeJJYCrZeAdnYxFL0sugZCas5oOiowJmPj9VXg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:19:10 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestCollectionsPhotoResponse.test_gets_location_on_collection_photos.yml
+++ b/tests/fixtures/cassettes/TestCollectionsPhotoResponse.test_gets_location_on_collection_photos.yml
@@ -1,0 +1,441 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.urls.lookupUser&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2F150102727%40N06%2F
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<user
+      id=\"150102727@N06\">\n\t<username>Ninara31</username>\n</user>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:17:56 GMT
+      Via:
+      - 1.1 5633f59304cdd2083a4c0ecbd4c997b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - rhAJ4wv5Ta2mHRw55RU2Iv8Azg29b_bmANwN_L0qfHcizgtx72QU9w==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:17:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:17:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=150102727%40N06
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<person
+      id=\"150102727@N06\" nsid=\"150102727@N06\" ispro=\"1\" is_deleted=\"0\" iconserver=\"513\"
+      iconfarm=\"1\" path_alias=\"\" has_stats=\"0\" pro_badge=\"standard\" expire=\"0\"
+      has_adfree=\"0\" has_free_standard_shipping=\"0\" has_free_educational_resources=\"0\">\n\t<username>Ninara31</username>\n\t<realname>Nina
+      R</realname>\n\t<location>Africa</location>\n\t<timezone label=\"Bangkok, Hanoi,
+      Jakarta\" offset=\"+07:00\" timezone_id=\"Asia/Bangkok\" timezone=\"55\" />\n\t<description>Thank
+      you for your visits, faves and comments. \n\nI have been working in Asia and
+      Africa. \n\nMost of my pictures are licenced with CC-BY (some rights reserved).
+      \ It means that you are allowed to use the photos without asking for permission,
+      but please credit the photos to the author (= Nina R) if possible. \nThe pictures
+      with people are mostly &amp;quot;all rights reserved&amp;quot;, which means:
+      not allowed to use. \nIf you have questions, contact me by Flickr mail.\n\n______________\n\n\nNina
+      is busy working and travelling in Africa. Usually, her mother makes post-processing
+      of the photos for her.</description>\n\t<photosurl>https://www.flickr.com/photos/150102727@N06/</photosurl>\n\t<profileurl>https://www.flickr.com/people/150102727@N06/</profileurl>\n\t<mobileurl>https://m.flickr.com/photostream.gne?id=150057405</mobileurl>\n\t<photos>\n\t\t<firstdatetaken>2015-02-20
+      13:40:53</firstdatetaken>\n\t\t<firstdate>1481389511</firstdate>\n\t\t<count>5429</count>\n\t</photos>\n</person>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '806'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:17:57 GMT
+      Via:
+      - 1.1 5633f59304cdd2083a4c0ecbd4c997b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6SuX8gnuXOOJl4xGtoZ1yXwBa3rwOnEKXoYO2_ykrOu6KhlUdWufFw==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:17:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?extras=license%2Cdate_upload%2Cdate_taken%2Cmedia%2Coriginal_format%2Cowner_name%2Curl_sq%2Curl_t%2Curl_s%2Curl_m%2Curl_o%2Ctags%2Cgeo%2Curl_q%2Curl_l%2Cdescription%2Csafety_level%2Crealname&method=flickr.photosets.getPhotos&page=1&per_page=10&photoset_id=72157700908640782&user_id=150102727%40N06
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157700908640782\" primary=\"32245604208\" owner=\"150102727@N06\" ownername=\"Ninara31\"
+      page=\"1\" per_page=\"10\" perpage=\"10\" pages=\"24\" title=\"Kenya Safari\"
+      total=\"236\">\n\t<photo id=\"53350921179\" secret=\"48e0e15d1b\" server=\"65535\"
+      farm=\"66\" title=\"Shimba Hills, Kenya\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\"
+      isfamily=\"0\" license=\"4\" safety_level=\"0\" dateupload=\"1700742804\" datetaken=\"2022-10-20
+      09:15:49\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Ninara31\"
+      realname=\"Nina R\" tags=\"kenya safari shimbahills giriama waterfall sheldrickfalls\"
+      originalsecret=\"9fc92d34f0\" originalformat=\"jpg\" latitude=\"-4.282466\"
+      longitude=\"39.430811\" accuracy=\"16\" context=\"0\" place_id=\"\" woeid=\"7868142\"
+      geo_is_public=\"1\" geo_is_contact=\"0\" geo_is_friend=\"0\" geo_is_family=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53350921179_48e0e15d1b_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53350921179_48e0e15d1b_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53350921179_48e0e15d1b_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53350921179_48e0e15d1b.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53350921179_9fc92d34f0_o.jpg\"
+      height_o=\"4000\" width_o=\"6000\" url_q=\"https://live.staticflickr.com/65535/53350921179_48e0e15d1b_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53350921179_48e0e15d1b_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description>Shimba Hills National Reserve
+      \nSheldrick Falls</description>\n\t</photo>\n\t<photo id=\"53349725017\" secret=\"546a94694a\"
+      server=\"65535\" farm=\"66\" title=\"Shimba Hills, Kenya\" isprimary=\"0\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"4\" safety_level=\"0\" dateupload=\"1700742803\"
+      datetaken=\"2022-10-20 08:58:19\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Ninara31\" realname=\"Nina R\" tags=\"kenya safari shimbahills giriama
+      path forest\" originalsecret=\"a99c943e77\" originalformat=\"jpg\" latitude=\"0\"
+      longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/53349725017_546a94694a_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53349725017_546a94694a_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53349725017_546a94694a_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53349725017_546a94694a.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53349725017_a99c943e77_o.jpg\"
+      height_o=\"4000\" width_o=\"6000\" url_q=\"https://live.staticflickr.com/65535/53349725017_546a94694a_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53349725017_546a94694a_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description>Shimba Hills National Reserve
+      \n\nGiriama Point </description>\n\t</photo>\n\t<photo id=\"53350919478\" secret=\"858b522261\"
+      server=\"65535\" farm=\"66\" title=\"Shimba Hills, Kenya\" isprimary=\"0\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"4\" safety_level=\"0\" dateupload=\"1700742804\"
+      datetaken=\"2022-10-20 08:53:40\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Ninara31\" realname=\"Nina R\" tags=\"kenya safari shimbahills giriama
+      waterfall sheldrickfalls ranger\" originalsecret=\"910112eb20\" originalformat=\"jpg\"
+      latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53350919478_858b522261_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53350919478_858b522261_t.jpg\"
+      height_t=\"82\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53350919478_858b522261_m.jpg\"
+      height_s=\"197\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53350919478_858b522261.jpg\"
+      height_m=\"411\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53350919478_910112eb20_o.jpg\"
+      height_o=\"2889\" width_o=\"3517\" url_q=\"https://live.staticflickr.com/65535/53350919478_858b522261_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53350919478_858b522261_b.jpg\"
+      height_l=\"841\" width_l=\"1024\">\n\t\t<description>Shimba Hills National Reserve</description>\n\t</photo>\n\t<photo
+      id=\"53351047905\" secret=\"36b82b7533\" server=\"65535\" farm=\"66\" title=\"Shimba
+      Hills, Kenya\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\"
+      license=\"4\" safety_level=\"0\" dateupload=\"1700742800\" datetaken=\"2022-10-20
+      07:54:46\" datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Ninara31\"
+      realname=\"Nina R\" tags=\"kenya safari shimbahills giriama road forest\" originalsecret=\"42261bc051\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53351047905_36b82b7533_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53351047905_36b82b7533_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53351047905_36b82b7533_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53351047905_36b82b7533.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53351047905_42261bc051_o.jpg\"
+      height_o=\"3049\" width_o=\"4573\" url_q=\"https://live.staticflickr.com/65535/53351047905_36b82b7533_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53351047905_36b82b7533_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description>Shimba Hills National Reserve
+      \n\nGiriama Point </description>\n\t</photo>\n\t<photo id=\"53350824423\" secret=\"0c26a03a11\"
+      server=\"65535\" farm=\"66\" title=\"Shimba Hills, Kenya\" isprimary=\"0\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"4\" safety_level=\"0\" dateupload=\"1700742801\"
+      datetaken=\"2022-10-20 07:52:36\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Ninara31\" realname=\"Nina R\" tags=\"kenya safari shimbahills giriama
+      road\" originalsecret=\"8d8c77d5e0\" originalformat=\"jpg\" latitude=\"0\" longitude=\"0\"
+      accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53350824423_0c26a03a11_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53350824423_0c26a03a11_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53350824423_0c26a03a11_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53350824423_0c26a03a11.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53350824423_8d8c77d5e0_o.jpg\"
+      height_o=\"4000\" width_o=\"6000\" url_q=\"https://live.staticflickr.com/65535/53350824423_0c26a03a11_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53350824423_0c26a03a11_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description>Shimba Hills National Reserve
+      \n\nGiriama Point </description>\n\t</photo>\n\t<photo id=\"53350597511\" secret=\"5e582b07f4\"
+      server=\"65535\" farm=\"66\" title=\"Shimba Hills, Kenya\" isprimary=\"0\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"4\" safety_level=\"0\" dateupload=\"1700742802\"
+      datetaken=\"2022-10-20 07:47:16\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Ninara31\" realname=\"Nina R\" tags=\"kenya safari shimbahills giriama
+      forest\" originalsecret=\"14e711a585\" originalformat=\"jpg\" latitude=\"-4.262277\"
+      longitude=\"39.438858\" accuracy=\"14\" context=\"0\" place_id=\"\" woeid=\"7868143\"
+      geo_is_public=\"1\" geo_is_contact=\"0\" geo_is_friend=\"0\" geo_is_family=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53350597511_5e582b07f4_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53350597511_5e582b07f4_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53350597511_5e582b07f4_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53350597511_5e582b07f4.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53350597511_14e711a585_o.jpg\"
+      height_o=\"2784\" width_o=\"4176\" url_q=\"https://live.staticflickr.com/65535/53350597511_5e582b07f4_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53350597511_5e582b07f4_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description>Shimba Hills National Reserve
+      \n\nGiriama Point </description>\n\t</photo>\n\t<photo id=\"53351046740\" secret=\"b3ac3f0504\"
+      server=\"65535\" farm=\"66\" title=\"Shimba Hills, Kenya\" isprimary=\"0\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"4\" safety_level=\"0\" dateupload=\"1700742801\"
+      datetaken=\"2022-10-20 07:47:05\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Ninara31\" realname=\"Nina R\" tags=\"kenya safari shimbahills giriama
+      forest\" originalsecret=\"072edfee96\" originalformat=\"jpg\" latitude=\"0\"
+      longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\"
+      url_sq=\"https://live.staticflickr.com/65535/53351046740_b3ac3f0504_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53351046740_b3ac3f0504_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53351046740_b3ac3f0504_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53351046740_b3ac3f0504.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53351046740_072edfee96_o.jpg\"
+      height_o=\"3012\" width_o=\"4518\" url_q=\"https://live.staticflickr.com/65535/53351046740_b3ac3f0504_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53351046740_b3ac3f0504_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description>Shimba Hills National Reserve
+      \n\nGiriama Point </description>\n\t</photo>\n\t<photo id=\"53351046265\" secret=\"504abba4ec\"
+      server=\"65535\" farm=\"66\" title=\"Tsavo West, Kenya\" isprimary=\"0\" ispublic=\"1\"
+      isfriend=\"0\" isfamily=\"0\" license=\"4\" safety_level=\"0\" dateupload=\"1700742793\"
+      datetaken=\"2022-10-19 16:23:11\" datetakengranularity=\"0\" datetakenunknown=\"0\"
+      ownername=\"Ninara31\" realname=\"Nina R\" tags=\"kenya safari shimbahills giriama\"
+      originalsecret=\"144ac5a196\" originalformat=\"jpg\" latitude=\"0\" longitude=\"0\"
+      accuracy=\"0\" context=\"0\" media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53351046265_504abba4ec_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53351046265_504abba4ec_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53351046265_504abba4ec_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53351046265_504abba4ec.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53351046265_144ac5a196_o.jpg\"
+      height_o=\"2986\" width_o=\"4479\" url_q=\"https://live.staticflickr.com/65535/53351046265_504abba4ec_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53351046265_504abba4ec_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"53351045730\" secret=\"b20331b890\" server=\"65535\" farm=\"66\" title=\"Tsavo
+      West, Kenya\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"4\"
+      safety_level=\"0\" dateupload=\"1700742793\" datetaken=\"2022-10-19 16:09:37\"
+      datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Ninara31\" realname=\"Nina
+      R\" tags=\"kenya safari shimbahills giriama waterfall\" originalsecret=\"1889b7ef4d\"
+      originalformat=\"jpg\" latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\"
+      media=\"photo\" media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53351045730_b20331b890_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53351045730_b20331b890_t.jpg\"
+      height_t=\"100\" width_t=\"67\" url_s=\"https://live.staticflickr.com/65535/53351045730_b20331b890_m.jpg\"
+      height_s=\"240\" width_s=\"160\" url_m=\"https://live.staticflickr.com/65535/53351045730_b20331b890.jpg\"
+      height_m=\"500\" width_m=\"333\" url_o=\"https://live.staticflickr.com/65535/53351045730_1889b7ef4d_o.jpg\"
+      height_o=\"6000\" width_o=\"4000\" url_q=\"https://live.staticflickr.com/65535/53351045730_b20331b890_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53351045730_b20331b890_b.jpg\"
+      height_l=\"1024\" width_l=\"683\">\n\t\t<description />\n\t</photo>\n\t<photo
+      id=\"53343158610\" secret=\"386d38df6e\" server=\"65535\" farm=\"66\" title=\"Tsavo
+      West, Kenya\" isprimary=\"0\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" license=\"4\"
+      safety_level=\"0\" dateupload=\"1700429412\" datetaken=\"2022-10-18 13:56:05\"
+      datetakengranularity=\"0\" datetakenunknown=\"0\" ownername=\"Ninara31\" realname=\"Nina
+      R\" tags=\"tsavowest africa draught nature wildlife taita lumoconservancy tsavo
+      savanna savannah road safari\" originalsecret=\"af1bea1c33\" originalformat=\"jpg\"
+      latitude=\"0\" longitude=\"0\" accuracy=\"0\" context=\"0\" media=\"photo\"
+      media_status=\"ready\" url_sq=\"https://live.staticflickr.com/65535/53343158610_386d38df6e_s.jpg\"
+      height_sq=\"75\" width_sq=\"75\" url_t=\"https://live.staticflickr.com/65535/53343158610_386d38df6e_t.jpg\"
+      height_t=\"67\" width_t=\"100\" url_s=\"https://live.staticflickr.com/65535/53343158610_386d38df6e_m.jpg\"
+      height_s=\"160\" width_s=\"240\" url_m=\"https://live.staticflickr.com/65535/53343158610_386d38df6e.jpg\"
+      height_m=\"333\" width_m=\"500\" url_o=\"https://live.staticflickr.com/65535/53343158610_af1bea1c33_o.jpg\"
+      height_o=\"2835\" width_o=\"4253\" url_q=\"https://live.staticflickr.com/65535/53343158610_386d38df6e_q.jpg\"
+      height_q=\"150\" width_q=\"150\" url_l=\"https://live.staticflickr.com/65535/53343158610_386d38df6e_b.jpg\"
+      height_l=\"683\" width_l=\"1024\">\n\t\t<description>Draught in Africa\n</description>\n\t</photo>\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1748'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:17:57 GMT
+      Via:
+      - 1.1 5633f59304cdd2083a4c0ecbd4c997b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - mOMhjwqx6p9atsVskQ3__UgWP-lrd5tysEREc1LOetGjbfTrGmjhVg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:17:57 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '395'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:17:57 GMT
+      Via:
+      - 1.1 5633f59304cdd2083a4c0ecbd4c997b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - qsPOlM_tS4BkuG3R8IqzW4NfAH2W_nm35NnjIjQ7wt2cOwCHhU3fmA==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:17:57 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photosets.getInfo&photoset_id=72157700908640782&user_id=150102727%40N06
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photoset
+      id=\"72157700908640782\" owner=\"150102727@N06\" username=\"Ninara31\" primary=\"32245604208\"
+      secret=\"09a54cdd37\" server=\"4896\" farm=\"5\" count_views=\"123\" count_comments=\"0\"
+      count_photos=\"236\" count_videos=\"0\" can_comment=\"0\" date_create=\"1543581851\"
+      date_update=\"1700743947\" photos=\"236\" visibility_can_see_set=\"1\" needs_interstitial=\"0\">\n\t<title>Kenya
+      Safari</title>\n\t<description>Shimba Hills\nTsavo West\nKichaka\nNakuru\nSamburu\n</description>\n</photoset>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '361'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:17:57 GMT
+      Via:
+      - 1.1 5633f59304cdd2083a4c0ecbd4c997b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - HBZpzd_eiHn1M6Gy_Lg8QSLNLsk29HoTmphH3s1nyKwvMw8fgIOiNA==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:17:57 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/TestGetSinglePhoto.test_gets_location_for_photo.yml
+++ b/tests/fixtures/cassettes/TestGetSinglePhoto.test_gets_location_for_photo.yml
@@ -11,116 +11,54 @@ interactions:
       host:
       - api.flickr.com
       user-agent:
-      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
-        hello@flickr.org)
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
     method: GET
-    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=52578982111
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=52994452213
   response:
     content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
-      id=\"52578982111\" secret=\"d282832bc4\" server=\"65535\" farm=\"66\" dateuploaded=\"1671696468\"
-      isfavorite=\"0\" license=\"0\" safety_level=\"0\" rotation=\"0\" views=\"169\"
-      media=\"photo\">\n\t<owner nsid=\"52568942@N05\" username=\"Rudr Peter | Smile
-      to the world |\" realname=\"Rudr Peter\" location=\"\" iconserver=\"65535\"
-      iconfarm=\"66\" path_alias=\"rudrpeter\">\n\t\t<gift gift_eligible=\"1\" new_flow=\"1\">\n\t\t\t<eligible_durations
-      />\n\t\t\t<eligible_durations />\n\t\t\t<eligible_durations />\n\t\t</gift>\n\t</owner>\n\t<title>Kanyakumari
-      sunrise shot with iphone and LR post production.</title>\n\t<description>Sunrise
-      at Kanyakumari, southern most tip of India. Follow @RudrPeter\n#instagram #instadaily
-      #RudrPeter #love #photography #clicks #Qatar #instagood #photooftheday #beautiful
-      #Nikon #NikonIndia #D850 #birds #happy #followme #nature #like4like #travel
-      #life #goodmorning\n#NikonQatar #City #Urban #flowers #landscape \n\n @2022-2099
-      Copyright Rudr Peter. All rights reserved under the International Copyright
-      laws. This picture and portions of this image should not be used in any print
-      and electronic form without permission from me</description>\n\t<visibility
-      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1671696468\"
-      taken=\"2022-12-22 07:00:55\" takengranularity=\"0\" takenunknown=\"0\" lastupdate=\"1673820910\"
+      id=\"52994452213\" secret=\"443d00faf8\" server=\"65535\" farm=\"66\" dateuploaded=\"1687469849\"
+      isfavorite=\"0\" license=\"4\" safety_level=\"0\" rotation=\"0\" originalsecret=\"33120c5330\"
+      originalformat=\"jpg\" views=\"114\" media=\"photo\">\n\t<owner nsid=\"150102727@N06\"
+      username=\"Ninara31\" realname=\"Nina R\" location=\"Africa\" iconserver=\"513\"
+      iconfarm=\"1\" path_alias=\"\">\n\t\t<gift gift_eligible=\"1\" new_flow=\"1\">\n\t\t\t<eligible_durations
+      />\n\t\t\t<eligible_durations />\n\t\t\t<eligible_durations />\n\t\t</gift>\n\t</owner>\n\t<title>Doho
+      Lodge, Ethiopia</title>\n\t<description>Afar, Doho Lodge</description>\n\t<visibility
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1687469849\"
+      taken=\"2021-05-16 12:16:36\" takengranularity=\"0\" takenunknown=\"0\" lastupdate=\"1688071361\"
       />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
-      cancomment=\"1\" canaddmeta=\"0\" />\n\t<usage candownload=\"0\" canblog=\"0\"
+      cancomment=\"1\" canaddmeta=\"0\" />\n\t<usage candownload=\"1\" canblog=\"0\"
       canprint=\"0\" canshare=\"1\" />\n\t<comments>0</comments>\n\t<notes />\n\t<people
-      haspeople=\"0\" />\n\t<tags>\n\t\t<tag id=\"52563602-52578982111-6930\" author=\"52568942@N05\"
-      authorname=\"Rudr Peter | Smile to the world |\" raw=\"indian ocean\" machine_tag=\"0\">indianocean</tag>\n\t\t<tag
-      id=\"52563602-52578982111-244794\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"bay of bengal\" machine_tag=\"0\">bayofbengal</tag>\n\t\t<tag
-      id=\"52563602-52578982111-1657901\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"triveni\" machine_tag=\"0\">triveni</tag>\n\t\t<tag
-      id=\"52563602-52578982111-315625\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"arabian sea\" machine_tag=\"0\">arabiansea</tag>\n\t\t<tag
-      id=\"52563602-52578982111-624999\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"vivekananda\" machine_tag=\"0\">vivekananda</tag>\n\t\t<tag
-      id=\"52563602-52578982111-393\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"india\" machine_tag=\"0\">india</tag>\n\t\t<tag
-      id=\"52563602-52578982111-108647\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"kanyakumari\" machine_tag=\"0\">kanyakumari</tag>\n\t\t<tag
-      id=\"52563602-52578982111-34638\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"goodmorning\" machine_tag=\"0\">goodmorning</tag>\n\t\t<tag
-      id=\"52563602-52578982111-240906\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"clicks\" machine_tag=\"0\">clicks</tag>\n\t\t<tag
-      id=\"52563602-52578982111-39\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"life\" machine_tag=\"0\">life</tag>\n\t\t<tag
-      id=\"52563602-52578982111-640\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"love\" machine_tag=\"0\">love</tag>\n\t\t<tag
-      id=\"52563602-52578982111-1935\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"photography\" machine_tag=\"0\">photography</tag>\n\t\t<tag
-      id=\"52563602-52578982111-103\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"City\" machine_tag=\"0\">city</tag>\n\t\t<tag
-      id=\"52563602-52578982111-75962530\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"instagood\" machine_tag=\"0\">instagood</tag>\n\t\t<tag
-      id=\"52563602-52578982111-221387723\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"NikonQatar\" machine_tag=\"0\">nikonqatar</tag>\n\t\t<tag
-      id=\"52563602-52578982111-85374185\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"RudrPeter\" machine_tag=\"0\">rudrpeter</tag>\n\t\t<tag
-      id=\"52563602-52578982111-1695\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"landscape\" machine_tag=\"0\">landscape</tag>\n\t\t<tag
-      id=\"52563602-52578982111-248155\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"followme\" machine_tag=\"0\">followme</tag>\n\t\t<tag
-      id=\"52563602-52578982111-92557042\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"like4like\" machine_tag=\"0\">like4like</tag>\n\t\t<tag
-      id=\"52563602-52578982111-791\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"nature\" machine_tag=\"0\">nature</tag>\n\t\t<tag
-      id=\"52563602-52578982111-72688492\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"instadaily\" machine_tag=\"0\">instadaily</tag>\n\t\t<tag
-      id=\"52563602-52578982111-2994\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"Nikon\" machine_tag=\"0\">nikon</tag>\n\t\t<tag
-      id=\"52563602-52578982111-1899\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"happy\" machine_tag=\"0\">happy</tag>\n\t\t<tag
-      id=\"52563602-52578982111-951\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"birds\" machine_tag=\"0\">birds</tag>\n\t\t<tag
-      id=\"52563602-52578982111-121\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"travel\" machine_tag=\"0\">travel</tag>\n\t\t<tag
-      id=\"52563602-52578982111-190835\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"photooftheday\" machine_tag=\"0\">photooftheday</tag>\n\t\t<tag
-      id=\"52563602-52578982111-876\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"beautiful\" machine_tag=\"0\">beautiful</tag>\n\t\t<tag
-      id=\"52563602-52578982111-2580064\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"D850\" machine_tag=\"0\">d850</tag>\n\t\t<tag
-      id=\"52563602-52578982111-103405\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"Qatar\" machine_tag=\"0\">qatar</tag>\n\t\t<tag
-      id=\"52563602-52578982111-59361684\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"instagram\" machine_tag=\"0\">instagram</tag>\n\t\t<tag
-      id=\"52563602-52578982111-14697151\" author=\"52568942@N05\" authorname=\"Rudr
-      Peter | Smile to the world |\" raw=\"NikonIndia\" machine_tag=\"0\">nikonindia</tag>\n\t\t<tag
-      id=\"52563602-52578982111-291\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"Urban\" machine_tag=\"0\">urban</tag>\n\t\t<tag
-      id=\"52563602-52578982111-140\" author=\"52568942@N05\" authorname=\"Rudr Peter
-      | Smile to the world |\" raw=\"flowers\" machine_tag=\"0\">flowers</tag>\n\t</tags>\n\t<location
-      latitude=\"8.079310\" longitude=\"77.550004\" accuracy=\"0\" context=\"0\">\n\t\t<locality>N\u0101ncherikudiyiruppu</locality>\n\t\t<county>Kanniyakumari</county>\n\t\t<region>Tamil
-      Nadu</region>\n\t\t<country>India</country>\n\t\t<neighbourhood />\n\t</location>\n\t<geoperms
+      haspeople=\"0\" />\n\t<tags>\n\t\t<tag id=\"150057405-52994452213-244713\" author=\"150102727@N06\"
+      authorname=\"Ninara31\" raw=\"Afar\" machine_tag=\"0\">afar</tag>\n\t\t<tag
+      id=\"150057405-52994452213-499262608\" author=\"150102727@N06\" authorname=\"Ninara31\"
+      raw=\"Doho Lodge\" machine_tag=\"0\">doholodge</tag>\n\t\t<tag id=\"150057405-52994452213-28446\"
+      author=\"150102727@N06\" authorname=\"Ninara31\" raw=\"Ethiopia\" machine_tag=\"0\">ethiopia</tag>\n\t\t<tag
+      id=\"150057405-52994452213-573195\" author=\"150102727@N06\" authorname=\"Ninara31\"
+      raw=\"Awash\" machine_tag=\"0\">awash</tag>\n\t\t<tag id=\"150057405-52994452213-791\"
+      author=\"150102727@N06\" authorname=\"Ninara31\" raw=\"Nature\" machine_tag=\"0\">nature</tag>\n\t\t<tag
+      id=\"150057405-52994452213-5079599\" author=\"150102727@N06\" authorname=\"Ninara31\"
+      raw=\"Awash National Park\" machine_tag=\"0\">awashnationalpark</tag>\n\t\t<tag
+      id=\"150057405-52994452213-35657\" author=\"150102727@N06\" authorname=\"Ninara31\"
+      raw=\"Hot spring\" machine_tag=\"0\">hotspring</tag>\n\t</tags>\n\t<location
+      latitude=\"9.135158\" longitude=\"40.083811\" accuracy=\"16\" context=\"0\">\n\t\t<locality>Galoch</locality>\n\t\t<neighbourhood
+      />\n\t\t<region>\u0100far</region>\n\t\t<country>Ethiopia</country>\n\t</location>\n\t<geoperms
       ispublic=\"1\" iscontact=\"0\" isfriend=\"0\" isfamily=\"0\" />\n\t<urls>\n\t\t<url
-      type=\"photopage\">https://www.flickr.com/photos/rudrpeter/52578982111/</url>\n\t</urls>\n</photo>\n</rsp>\n"
+      type=\"photopage\">https://www.flickr.com/photos/150102727@N06/52994452213/</url>\n\t</urls>\n</photo>\n</rsp>\n"
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '1648'
+      - '931'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Wed, 15 Nov 2023 16:42:18 GMT
+      - Sat, 02 Dec 2023 20:16:12 GMT
       Via:
-      - 1.1 6bb394a3710cfad0602e35600376a9b0.cloudfront.net (CloudFront)
+      - 1.1 dd1211d51ecc66d1523e03934a660f3a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - jMlA5R7gE09Dc1ZSG5Or4mgpxXqSmiZO0ZkVoVZIJ08Kk9bbzo6FQQ==
+      - z_UBW_kHQB8Pb6IXy9aU6fUAZXbXtqGc0eXfUeXaxM3KEhfCLjB2fQ==
       X-Amz-Cf-Pop:
-      - EZE50-P1
+      - LHR50-P8
       X-Cache:
       - Miss from cloudfront
       content-encoding:
@@ -128,8 +66,10 @@ interactions:
       server:
       - Apache/2.4.58 (Ubuntu)
       set-cookie:
-      - ccc=%7B%22needsConsent%22%3Afalse%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Fri, 15-Dec-2023 16:42:18 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:16:12 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:16:12 GMT; Max-Age=2592000; path=/; domain=.flickr.com
       vary:
       - Accept-Encoding
       x-frame-options:
@@ -148,61 +88,66 @@ interactions:
       connection:
       - keep-alive
       cookie:
-      - ccc=%7B%22needsConsent%22%3Afalse%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
       host:
       - api.flickr.com
       user-agent:
-      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
-        hello@flickr.org)
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
     method: GET
-    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=52578982111
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=52994452213
   response:
     content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<sizes
-      canblog=\"0\" canprint=\"0\" candownload=\"0\">\n\t<size label=\"Square\" width=\"75\"
-      height=\"75\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_s.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/sq/\" media=\"photo\"
-      />\n\t<size label=\"Large Square\" width=\"150\" height=\"150\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_q.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/q/\" media=\"photo\"
-      />\n\t<size label=\"Thumbnail\" width=\"75\" height=\"100\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_t.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/t/\" media=\"photo\"
-      />\n\t<size label=\"Small\" width=\"180\" height=\"240\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_m.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/s/\" media=\"photo\"
-      />\n\t<size label=\"Small 320\" width=\"240\" height=\"320\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_n.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/n/\" media=\"photo\"
-      />\n\t<size label=\"Small 400\" width=\"300\" height=\"400\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_w.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/w/\" media=\"photo\"
-      />\n\t<size label=\"Medium\" width=\"375\" height=\"500\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/m/\" media=\"photo\"
-      />\n\t<size label=\"Medium 640\" width=\"480\" height=\"640\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_z.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/z/\" media=\"photo\"
-      />\n\t<size label=\"Medium 800\" width=\"600\" height=\"800\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_c.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/c/\" media=\"photo\"
-      />\n\t<size label=\"Large\" width=\"768\" height=\"1024\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_b.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/l/\" media=\"photo\"
-      />\n\t<size label=\"Large 1600\" width=\"1200\" height=\"1600\" source=\"https://live.staticflickr.com/65535/52578982111_3c18bf609f_h.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/h/\" media=\"photo\"
-      />\n\t<size label=\"Large 2048\" width=\"1536\" height=\"2048\" source=\"https://live.staticflickr.com/65535/52578982111_4031739d43_k.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/k/\" media=\"photo\"
-      />\n\t<size label=\"X-Large 3K\" width=\"2304\" height=\"3072\" source=\"https://live.staticflickr.com/65535/52578982111_588535ec4d_3k.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/3k/\" media=\"photo\"
-      />\n\t<size label=\"X-Large 4K\" width=\"3024\" height=\"4032\" source=\"https://live.staticflickr.com/65535/52578982111_272d1bfa97_4k.jpg\"
-      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/4k/\" media=\"photo\"
+      canblog=\"0\" canprint=\"0\" candownload=\"1\">\n\t<size label=\"Square\" width=\"75\"
+      height=\"75\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_s.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/sq/\" media=\"photo\"
+      />\n\t<size label=\"Large Square\" width=\"150\" height=\"150\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_q.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/q/\" media=\"photo\"
+      />\n\t<size label=\"Thumbnail\" width=\"100\" height=\"67\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_t.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/t/\" media=\"photo\"
+      />\n\t<size label=\"Small\" width=\"240\" height=\"160\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_m.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/s/\" media=\"photo\"
+      />\n\t<size label=\"Small 320\" width=\"320\" height=\"213\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_n.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/n/\" media=\"photo\"
+      />\n\t<size label=\"Small 400\" width=\"400\" height=\"267\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_w.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/w/\" media=\"photo\"
+      />\n\t<size label=\"Medium\" width=\"500\" height=\"333\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/m/\" media=\"photo\"
+      />\n\t<size label=\"Medium 640\" width=\"640\" height=\"427\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_z.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/z/\" media=\"photo\"
+      />\n\t<size label=\"Medium 800\" width=\"800\" height=\"533\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_c.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/c/\" media=\"photo\"
+      />\n\t<size label=\"Large\" width=\"1024\" height=\"683\" source=\"https://live.staticflickr.com/65535/52994452213_443d00faf8_b.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/l/\" media=\"photo\"
+      />\n\t<size label=\"Large 1600\" width=\"1600\" height=\"1067\" source=\"https://live.staticflickr.com/65535/52994452213_bed673dd48_h.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/h/\" media=\"photo\"
+      />\n\t<size label=\"Large 2048\" width=\"2048\" height=\"1365\" source=\"https://live.staticflickr.com/65535/52994452213_b2133393d8_k.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/k/\" media=\"photo\"
+      />\n\t<size label=\"X-Large 3K\" width=\"3072\" height=\"2048\" source=\"https://live.staticflickr.com/65535/52994452213_e98bc6454b_3k.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/3k/\" media=\"photo\"
+      />\n\t<size label=\"X-Large 4K\" width=\"4096\" height=\"2731\" source=\"https://live.staticflickr.com/65535/52994452213_a52cb78174_4k.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/4k/\" media=\"photo\"
+      />\n\t<size label=\"X-Large 5K\" width=\"5120\" height=\"3413\" source=\"https://live.staticflickr.com/65535/52994452213_3b0896eb9e_5k.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/5k/\" media=\"photo\"
+      />\n\t<size label=\"X-Large 6K\" width=\"6000\" height=\"4000\" source=\"https://live.staticflickr.com/65535/52994452213_0e27fc79e2_6k.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/6k/\" media=\"photo\"
+      />\n\t<size label=\"Original\" width=\"6000\" height=\"4000\" source=\"https://live.staticflickr.com/65535/52994452213_33120c5330_o.jpg\"
+      url=\"https://www.flickr.com/photos/150102727@N06/52994452213/sizes/o/\" media=\"photo\"
       />\n</sizes>\n</rsp>\n"
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '523'
+      - '604'
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Wed, 15 Nov 2023 16:42:18 GMT
+      - Sat, 02 Dec 2023 20:16:12 GMT
       Via:
-      - 1.1 6bb394a3710cfad0602e35600376a9b0.cloudfront.net (CloudFront)
+      - 1.1 dd1211d51ecc66d1523e03934a660f3a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - OKwIvjMKF3CmI0rk0IwncZpkU_vuuJB1W1gF6rdNCDRGFvE8SinxZQ==
+      - FWlF-IG-RSxdJwJC_uAPhn9W9RSIaqHuXuVBPJSevdq08GQc06sOHw==
       X-Amz-Cf-Pop:
-      - EZE50-P1
+      - LHR50-P8
       X-Cache:
       - Miss from cloudfront
       content-encoding:
@@ -210,8 +155,8 @@ interactions:
       server:
       - Apache/2.4.58 (Ubuntu)
       set-cookie:
-      - ccc=%7B%22needsConsent%22%3Afalse%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Fri, 15-Dec-2023 16:42:18 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:16:12 GMT; Max-Age=2592000; path=/; domain=.flickr.com
       vary:
       - Accept-Encoding
       x-frame-options:
@@ -230,12 +175,11 @@ interactions:
       connection:
       - keep-alive
       cookie:
-      - ccc=%7B%22needsConsent%22%3Afalse%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
       host:
       - api.flickr.com
       user-agent:
-      - flickr-photos-api/dev (https://github.com/Flickr-Foundation/flickr-photos-api;
-        hello@flickr.org)
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
     method: GET
     uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
   response:
@@ -262,13 +206,13 @@ interactions:
       Content-Type:
       - text/xml; charset=utf-8
       Date:
-      - Wed, 15 Nov 2023 16:42:19 GMT
+      - Sat, 02 Dec 2023 20:16:12 GMT
       Via:
-      - 1.1 6bb394a3710cfad0602e35600376a9b0.cloudfront.net (CloudFront)
+      - 1.1 dd1211d51ecc66d1523e03934a660f3a.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - T5MQh-JjQGQROWeRcMDG3Re01qBncpPtwhV7f0HqvVH6nzEOCdWx3w==
+      - CZZl-3A__Ql-5d8ekKmKNWBhPJ60-4oYkGEoVC_uwy3lPgfpGW0suQ==
       X-Amz-Cf-Pop:
-      - EZE50-P1
+      - LHR50-P8
       X-Cache:
       - Miss from cloudfront
       content-encoding:
@@ -276,8 +220,8 @@ interactions:
       server:
       - Apache/2.4.58 (Ubuntu)
       set-cookie:
-      - ccc=%7B%22needsConsent%22%3Afalse%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Fri, 15-Dec-2023 16:42:18 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:16:12 GMT; Max-Age=2592000; path=/; domain=.flickr.com
       vary:
       - Accept-Encoding
       x-frame-options:

--- a/tests/fixtures/cassettes/TestGetSinglePhoto.test_it_discards_location_if_accuracy_is_zero.yml
+++ b/tests/fixtures/cassettes/TestGetSinglePhoto.test_it_discards_location_if_accuracy_is_zero.yml
@@ -1,0 +1,288 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=52578982111
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photo
+      id=\"52578982111\" secret=\"d282832bc4\" server=\"65535\" farm=\"66\" dateuploaded=\"1671696468\"
+      isfavorite=\"0\" license=\"0\" safety_level=\"0\" rotation=\"0\" views=\"182\"
+      media=\"photo\">\n\t<owner nsid=\"52568942@N05\" username=\"Rudr Peter | Smile
+      to the world |\" realname=\"Rudr Peter\" location=\"\" iconserver=\"65535\"
+      iconfarm=\"66\" path_alias=\"rudrpeter\">\n\t\t<gift gift_eligible=\"1\" new_flow=\"1\">\n\t\t\t<eligible_durations
+      />\n\t\t\t<eligible_durations />\n\t\t\t<eligible_durations />\n\t\t</gift>\n\t</owner>\n\t<title>Kanyakumari
+      sunrise shot with iphone and LR post production.</title>\n\t<description>Sunrise
+      at Kanyakumari, southern most tip of India. Follow @RudrPeter\n#instagram #instadaily
+      #RudrPeter #love #photography #clicks #Qatar #instagood #photooftheday #beautiful
+      #Nikon #NikonIndia #D850 #birds #happy #followme #nature #like4like #travel
+      #life #goodmorning\n#NikonQatar #City #Urban #flowers #landscape \n\n @2022-2099
+      Copyright Rudr Peter. All rights reserved under the International Copyright
+      laws. This picture and portions of this image should not be used in any print
+      and electronic form without permission from me</description>\n\t<visibility
+      ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n\t<dates posted=\"1671696468\"
+      taken=\"2022-12-22 07:00:55\" takengranularity=\"0\" takenunknown=\"0\" lastupdate=\"1673820910\"
+      />\n\t<editability cancomment=\"0\" canaddmeta=\"0\" />\n\t<publiceditability
+      cancomment=\"1\" canaddmeta=\"0\" />\n\t<usage candownload=\"0\" canblog=\"0\"
+      canprint=\"0\" canshare=\"1\" />\n\t<comments>0</comments>\n\t<notes />\n\t<people
+      haspeople=\"0\" />\n\t<tags>\n\t\t<tag id=\"52563602-52578982111-6930\" author=\"52568942@N05\"
+      authorname=\"Rudr Peter | Smile to the world |\" raw=\"indian ocean\" machine_tag=\"\">indianocean</tag>\n\t\t<tag
+      id=\"52563602-52578982111-244794\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"bay of bengal\" machine_tag=\"\">bayofbengal</tag>\n\t\t<tag
+      id=\"52563602-52578982111-1657901\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"triveni\" machine_tag=\"\">triveni</tag>\n\t\t<tag
+      id=\"52563602-52578982111-315625\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"arabian sea\" machine_tag=\"\">arabiansea</tag>\n\t\t<tag
+      id=\"52563602-52578982111-624999\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"vivekananda\" machine_tag=\"\">vivekananda</tag>\n\t\t<tag
+      id=\"52563602-52578982111-393\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"india\" machine_tag=\"\">india</tag>\n\t\t<tag
+      id=\"52563602-52578982111-108647\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"kanyakumari\" machine_tag=\"\">kanyakumari</tag>\n\t\t<tag
+      id=\"52563602-52578982111-34638\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"goodmorning\" machine_tag=\"\">goodmorning</tag>\n\t\t<tag
+      id=\"52563602-52578982111-240906\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"clicks\" machine_tag=\"\">clicks</tag>\n\t\t<tag
+      id=\"52563602-52578982111-39\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"life\" machine_tag=\"\">life</tag>\n\t\t<tag
+      id=\"52563602-52578982111-640\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"love\" machine_tag=\"\">love</tag>\n\t\t<tag
+      id=\"52563602-52578982111-1935\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"photography\" machine_tag=\"\">photography</tag>\n\t\t<tag
+      id=\"52563602-52578982111-103\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"City\" machine_tag=\"\">city</tag>\n\t\t<tag
+      id=\"52563602-52578982111-75962530\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"instagood\" machine_tag=\"\">instagood</tag>\n\t\t<tag
+      id=\"52563602-52578982111-221387723\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"NikonQatar\" machine_tag=\"\">nikonqatar</tag>\n\t\t<tag
+      id=\"52563602-52578982111-85374185\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"RudrPeter\" machine_tag=\"\">rudrpeter</tag>\n\t\t<tag
+      id=\"52563602-52578982111-1695\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"landscape\" machine_tag=\"\">landscape</tag>\n\t\t<tag
+      id=\"52563602-52578982111-248155\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"followme\" machine_tag=\"\">followme</tag>\n\t\t<tag
+      id=\"52563602-52578982111-92557042\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"like4like\" machine_tag=\"\">like4like</tag>\n\t\t<tag
+      id=\"52563602-52578982111-791\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"nature\" machine_tag=\"\">nature</tag>\n\t\t<tag
+      id=\"52563602-52578982111-72688492\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"instadaily\" machine_tag=\"\">instadaily</tag>\n\t\t<tag
+      id=\"52563602-52578982111-2994\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"Nikon\" machine_tag=\"\">nikon</tag>\n\t\t<tag
+      id=\"52563602-52578982111-1899\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"happy\" machine_tag=\"\">happy</tag>\n\t\t<tag
+      id=\"52563602-52578982111-951\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"birds\" machine_tag=\"\">birds</tag>\n\t\t<tag
+      id=\"52563602-52578982111-121\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"travel\" machine_tag=\"\">travel</tag>\n\t\t<tag
+      id=\"52563602-52578982111-190835\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"photooftheday\" machine_tag=\"\">photooftheday</tag>\n\t\t<tag
+      id=\"52563602-52578982111-876\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"beautiful\" machine_tag=\"\">beautiful</tag>\n\t\t<tag
+      id=\"52563602-52578982111-2580064\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"D850\" machine_tag=\"\">d850</tag>\n\t\t<tag
+      id=\"52563602-52578982111-103405\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"Qatar\" machine_tag=\"\">qatar</tag>\n\t\t<tag
+      id=\"52563602-52578982111-59361684\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"instagram\" machine_tag=\"\">instagram</tag>\n\t\t<tag
+      id=\"52563602-52578982111-14697151\" author=\"52568942@N05\" authorname=\"Rudr
+      Peter | Smile to the world |\" raw=\"NikonIndia\" machine_tag=\"\">nikonindia</tag>\n\t\t<tag
+      id=\"52563602-52578982111-291\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"Urban\" machine_tag=\"\">urban</tag>\n\t\t<tag
+      id=\"52563602-52578982111-140\" author=\"52568942@N05\" authorname=\"Rudr Peter
+      | Smile to the world |\" raw=\"flowers\" machine_tag=\"\">flowers</tag>\n\t</tags>\n\t<location
+      latitude=\"8.079310\" longitude=\"77.550004\" accuracy=\"0\" context=\"0\">\n\t\t<locality>N\u0101ncherikudiyiruppu</locality>\n\t\t<county>Kanniyakumari</county>\n\t\t<region>Tamil
+      Nadu</region>\n\t\t<country>India</country>\n\t\t<neighbourhood />\n\t</location>\n\t<geoperms
+      ispublic=\"1\" iscontact=\"0\" isfriend=\"0\" isfamily=\"0\" />\n\t<urls>\n\t\t<url
+      type=\"photopage\">https://www.flickr.com/photos/rudrpeter/52578982111/</url>\n\t</urls>\n</photo>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1646'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:08:19 GMT
+      Via:
+      - 1.1 743e66b1e30941714e613f42d795162e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - g6UbKPuoy5qDGwXLIBFFeHCDYODLg5BtLasQ_QQ2BLqMiM-zzD6cJQ==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:08:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:08:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=52578982111
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<sizes
+      canblog=\"0\" canprint=\"0\" candownload=\"0\">\n\t<size label=\"Square\" width=\"75\"
+      height=\"75\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_s.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/sq/\" media=\"photo\"
+      />\n\t<size label=\"Large Square\" width=\"150\" height=\"150\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_q.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/q/\" media=\"photo\"
+      />\n\t<size label=\"Thumbnail\" width=\"75\" height=\"100\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_t.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/t/\" media=\"photo\"
+      />\n\t<size label=\"Small\" width=\"180\" height=\"240\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_m.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/s/\" media=\"photo\"
+      />\n\t<size label=\"Small 320\" width=\"240\" height=\"320\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_n.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/n/\" media=\"photo\"
+      />\n\t<size label=\"Small 400\" width=\"300\" height=\"400\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_w.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/w/\" media=\"photo\"
+      />\n\t<size label=\"Medium\" width=\"375\" height=\"500\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/m/\" media=\"photo\"
+      />\n\t<size label=\"Medium 640\" width=\"480\" height=\"640\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_z.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/z/\" media=\"photo\"
+      />\n\t<size label=\"Medium 800\" width=\"600\" height=\"800\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_c.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/c/\" media=\"photo\"
+      />\n\t<size label=\"Large\" width=\"768\" height=\"1024\" source=\"https://live.staticflickr.com/65535/52578982111_d282832bc4_b.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/l/\" media=\"photo\"
+      />\n\t<size label=\"Large 1600\" width=\"1200\" height=\"1600\" source=\"https://live.staticflickr.com/65535/52578982111_3c18bf609f_h.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/h/\" media=\"photo\"
+      />\n\t<size label=\"Large 2048\" width=\"1536\" height=\"2048\" source=\"https://live.staticflickr.com/65535/52578982111_4031739d43_k.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/k/\" media=\"photo\"
+      />\n\t<size label=\"X-Large 3K\" width=\"2304\" height=\"3072\" source=\"https://live.staticflickr.com/65535/52578982111_588535ec4d_3k.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/3k/\" media=\"photo\"
+      />\n\t<size label=\"X-Large 4K\" width=\"3024\" height=\"4032\" source=\"https://live.staticflickr.com/65535/52578982111_272d1bfa97_4k.jpg\"
+      url=\"https://www.flickr.com/photos/rudrpeter/52578982111/sizes/4k/\" media=\"photo\"
+      />\n</sizes>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '523'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:08:19 GMT
+      Via:
+      - 1.1 743e66b1e30941714e613f42d795162e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XGtkhtKQ2buDRGYZtApZs2VgWXeylSW7tZvQt62ae4wlGmZGcQAw7w==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:08:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    content: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<licenses>\n\t<license
+      id=\"0\" name=\"All Rights Reserved\" url=\"\" />\n\t<license id=\"4\" name=\"Attribution
+      License\" url=\"https://creativecommons.org/licenses/by/2.0/\" />\n\t<license
+      id=\"6\" name=\"Attribution-NoDerivs License\" url=\"https://creativecommons.org/licenses/by-nd/2.0/\"
+      />\n\t<license id=\"3\" name=\"Attribution-NonCommercial-NoDerivs License\"
+      url=\"https://creativecommons.org/licenses/by-nc-nd/2.0/\" />\n\t<license id=\"2\"
+      name=\"Attribution-NonCommercial License\" url=\"https://creativecommons.org/licenses/by-nc/2.0/\"
+      />\n\t<license id=\"1\" name=\"Attribution-NonCommercial-ShareAlike License\"
+      url=\"https://creativecommons.org/licenses/by-nc-sa/2.0/\" />\n\t<license id=\"5\"
+      name=\"Attribution-ShareAlike License\" url=\"https://creativecommons.org/licenses/by-sa/2.0/\"
+      />\n\t<license id=\"7\" name=\"No known copyright restrictions\" url=\"https://www.flickr.com/commons/usage/\"
+      />\n\t<license id=\"8\" name=\"United States Government Work\" url=\"http://www.usa.gov/copyright.shtml\"
+      />\n\t<license id=\"9\" name=\"Public Domain Dedication (CC0)\" url=\"https://creativecommons.org/publicdomain/zero/1.0/\"
+      />\n\t<license id=\"10\" name=\"Public Domain Mark\" url=\"https://creativecommons.org/publicdomain/mark/1.0/\"
+      />\n</licenses>\n</rsp>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '395'
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Sat, 02 Dec 2023 20:08:19 GMT
+      Via:
+      - 1.1 743e66b1e30941714e613f42d795162e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4OmOKZK7J88MkDroZ_KK-XKA8Phwg9C-tVr_qm59h3NlzsAg2RNczg==
+      X-Amz-Cf-Pop:
+      - LHR50-P8
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - Apache/2.4.58 (Ubuntu)
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Mon, 01-Jan-2024 20:08:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-robots-tag:
+      - noindex
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
We're never going to use this information because we don't trust it, so better just to throw it away than risk a downstream caller using it as bad data.

Part of https://github.com/Flickr-Foundation/flickypedia/issues/36