### PR TITLE
Improve how location information is shown in the SDC preview

### DIFF
--- a/src/flickypedia/uploadr/templates/prepare_info/sdc_value.html
+++ b/src/flickypedia/uploadr/templates/prepare_info/sdc_value.html
@@ -29,7 +29,12 @@
   {{ datavalue.value | wikidata_date }}
 
 {% elif datavalue.type == "globecoordinate" %}
-  {{ datavalue.value.longitude }}&deg;E, {{ datavalue.value.latitude }}&deg;N
+  {% with lat = datavalue.value.latitude %}
+    {{ lat|abs }}&deg;{% if lat > 0 %}N{% else %}S{% endif %},
+  {% endwith %}
+  {% with long = datavalue.value.longitude %}
+    {{ long|abs }}&deg;{% if long > 0 %}E{% else %}W{% endif %}
+  {% endwith %}
 
 {% else %}
   {{ datavalue }}


### PR DESCRIPTION
For https://github.com/Flickr-Foundation/flickypedia/issues/36

This enables nicer messages like "25.683322&deg;S, 54.454829&deg;W" rather than dumping the raw JSON straight into the page.