### PR TITLE
Devise a method for passing API URLs to the "prepare info" form

### DIFF
--- a/src/flickypedia/uploadr/static/flickypedia.js
+++ b/src/flickypedia/uploadr/static/flickypedia.js
@@ -32,7 +32,7 @@ function prependHttpsToFormValue(inputElement) {
  * If the title is rejected, we add visible red text below the box
  * and a validation prompt, so the form can't be submitted.
  */
-function addTitleValidatorTo(inputElement) {
+function addTitleValidatorTo(inputElement, titleValidatorUrl) {
   const errorElement = document.querySelector(`p[for="${inputElement.id}"]`);
 
   inputElement.addEventListener("blur", function () {
@@ -54,7 +54,7 @@ function addTitleValidatorTo(inputElement) {
     const originalFormat = inputElement.getAttribute("data-originalformat");
     const title = `File:${inputElement.value}.${originalFormat}`;
 
-    fetch(`/api/validate_title?title=${title}`)
+    fetch(`${titleValidatorUrl}?title=${title}`)
       .then((response) => response.json())
       .then(function (json) {
 
@@ -137,7 +137,7 @@ function addCharCounterTo(inputElement, counterElement) {
  * We hide the <textarea> and insert an <input> field that will have
  * an associated autocomplete function.
  */
-function addInteractiveCategoriesTo(categoriesElement, parentForm) {
+function addInteractiveCategoriesTo(categoriesElement, parentForm, findMatchingCategoriesUrl) {
   const textAreaElement = categoriesElement.querySelector("textarea");
 
   /* Hide the original <textarea> */
@@ -309,7 +309,7 @@ function addInteractiveCategoriesTo(categoriesElement, parentForm) {
 
     autocompleteContainer.appendChild(autocompleteElement);
 
-    fetch(`/api/find_matching_categories?query=${inputElement.value}`)
+    fetch(`${findMatchingCategoriesUrl}?query=${inputElement.value}`)
       .then((response) => response.json())
       .then(function (json) {
         for (i = 0; i < json.length; i++) {

--- a/src/flickypedia/uploadr/templates/prepare_info/index.html
+++ b/src/flickypedia/uploadr/templates/prepare_info/index.html
@@ -6,10 +6,17 @@
   <script src="{{ url_for('static', filename='flickypedia.js') }}"></script>
 
   <script>
+    /*
+     * Note: we pass the API URLs as a variable from the page so we can
+     * use the `url_for()` helper in Flask to get URLs in our JavaScript --
+     * this avoids hard-coding them and stuff breaking if we rearrange URLs.
+     */
+    const apiUrls = {{ api_urls | tojson }};
+
     window.onload = function() {
       document
         .querySelectorAll('input[data-type="title"]')
-        .forEach(input => addTitleValidatorTo(input));
+        .forEach(input => addTitleValidatorTo(input, apiUrls["validate_title"]));
 
       document
         .querySelectorAll('textarea[data-type="short_caption"]')
@@ -25,7 +32,7 @@
       document
         .querySelectorAll('.categories')
         .forEach(categoriesElement =>
-           addInteractiveCategoriesTo(categoriesElement, parentForm)
+           addInteractiveCategoriesTo(categoriesElement, parentForm, apiUrls["find_matching_categories"])
         );
     }
   </script>

--- a/src/flickypedia/uploadr/views/prepare_info.py
+++ b/src/flickypedia/uploadr/views/prepare_info.py
@@ -239,6 +239,10 @@ def prepare_info() -> ViewResponse:
         photo_fields=[
             field for field in prepare_info_form if field.id.startswith("photo_")
         ],
+        api_urls={
+            "validate_title": url_for("validate_title_api"),
+            "find_matching_categories": url_for("find_matching_categories_api"),
+        },
     )
 
 


### PR DESCRIPTION
This avoids hard-coding them in the JavaScript, which should mean they update automatically when we run Flickypedia behind a sub-path, i.e. flickr.org/tools/flickypedia

This is required for #244 and extracted from #268