### PR TITLE
You only need to log in to Flickr once

### DIFF
--- a/src/flickypedia/uploadr/auth/flickr.py
+++ b/src/flickypedia/uploadr/auth/flickr.py
@@ -153,6 +153,12 @@ def oauth2_authorize_flickr() -> ViewResponse:
     except KeyError:
         abort(400)
 
+    # If the user is already logged in to Flickr, we don't need to send
+    # them back through Flickr's OAuth flow -- the tokens we get don't
+    # expire, so we can presume they're still good.
+    if current_user.encrypted_flickr_token is not None:
+        return redirect(next_url)
+
     oauth_config = current_app.config["OAUTH_PROVIDERS"]["flickr"]
 
     client = OAuth1Client(

--- a/tests/uploadr/test_auth_can_log_in_to_flickr.py
+++ b/tests/uploadr/test_auth_can_log_in_to_flickr.py
@@ -73,3 +73,14 @@ def test_can_get_token_from_flickr(
         "user_nsid": "199246608@N02",
         "username": "cefarrjf87",
     }
+
+    # Now check that if I try to log in a second time, I'm sent directly
+    # to my target, not back to Flickr's OAuth.
+    second_login_resp = logged_in_client.get(
+        "/authorize/flickr?next_url=http://localhost:5000/post_comments"
+    )
+
+    assert second_login_resp.status_code == 302
+    assert (
+        second_login_resp.headers["location"] == "http://localhost:5000/post_comments"
+    )


### PR DESCRIPTION
If somebody has logged in to Flickr and we have a saved token in their session, we don't need to send them back to Flickr to log in again each time.