### PR TITLE
Add a correct model/example for the "descriptions" field

### DIFF
--- a/src/flickypedia/apis/snapshots.py
+++ b/src/flickypedia/apis/snapshots.py
@@ -15,7 +15,7 @@ from flickypedia.types import Path, validate_typeddict
 from flickypedia.types.structured_data import ExistingClaims
 
 
-class Label(TypedDict):
+class MonolingualValue(TypedDict):
     language: str
     value: str
 
@@ -31,8 +31,8 @@ SnapshotEntry = TypedDict(
         "lastrevid": int,
         "modified": "str",
         "statements": ExistingClaims,
-        "labels": dict[str, Label],
-        "descriptions": dict[str, str],
+        "labels": dict[str, MonolingualValue],
+        "descriptions": dict[str, MonolingualValue],
     },
 )
 
@@ -59,12 +59,6 @@ def parse_sdc_snapshot(path: Path) -> Generator[SnapshotEntry, None, None]:
                 continue
 
             data = json.loads(line.replace(b",\n", b""))
-
-            # I've never actually seen what these look like, so I'm not
-            # sure I'm modelling them correctly -- so if/when I get
-            # an example, log it for inspection.
-            if data["descriptions"]:
-                pprint(data["descriptions"])
 
             try:
                 yield validate_typeddict(data, model=SnapshotEntry)

--- a/tests/apis/test_snapshots.py
+++ b/tests/apis/test_snapshots.py
@@ -32,3 +32,29 @@ class TestSnapshotEntryType:
         }
 
         validate_typeddict(entry, model=SnapshotEntry)
+
+    def test_handles_descriptions(self) -> None:
+        entry = {
+  "descriptions": {
+    "de": {
+      "language": "de",
+      "value": "Marienkapelle neben Haus Visbeck in der Bauerschaft Dernekamp, Kirchspiel, Dülmen, Nordrhein-Westfalen, Deutschland"
+    },
+    "en": {
+      "language": "en",
+      "value": "St Mary’s Chapel next to Visbeck manor in the Dernekamp hamlet, Kirchspiel, Dülmen, North Rhine-Westphalia, Germany"
+    }
+  },
+  "id": "M25872413",
+  "labels": {},
+  "lastrevid": 795294648,
+  "modified": "2023-08-23T09:59:31Z",
+  "ns": 6,
+  "pageid": 25872413,
+  "statements": {},
+  "title": "File:Kirchspiel (Dülmen), Visbeck, Marienkapelle -- 2010.jpg",
+  "type": "mediainfo"
+}
+
+
+        validate_typeddict(entry, model=SnapshotEntry)


### PR DESCRIPTION
This helps with parsing the snapshots, which is part of #331.