### PR TITLE
Add a function for parsing Wikimedia Commons URLs

### DIFF
--- a/src/flickypedia/apis/wikimedia/__init__.py
+++ b/src/flickypedia/apis/wikimedia/__init__.py
@@ -7,11 +7,13 @@ from .exceptions import (
     DuplicatePhotoUploadException,
 )
 from .languages import top_n_languages, LanguageMatch
+from .url_parser import get_filename_from_url
 
 
 __all__ = [
     "DuplicateFilenameUploadException",
     "DuplicatePhotoUploadException",
+    "get_filename_from_url",
     "InvalidAccessTokenException",
     "LanguageMatch",
     "UnknownWikimediaApiException",

--- a/src/flickypedia/apis/wikimedia/url_parser.py
+++ b/src/flickypedia/apis/wikimedia/url_parser.py
@@ -1,0 +1,22 @@
+import re
+
+import hyperlink
+
+
+def get_filename_from_url(url: str) -> str:
+    """
+    Given a URL to a file on Commons, return the name of the file.
+
+        >>> get_filename_from_url('https://commons.wikimedia.org/wiki/File:Cat.jpg')
+        'Cat.jpg'
+
+    """
+    u = hyperlink.DecodedURL.from_text(url)
+
+    if u.host != "commons.wikimedia.org":
+        raise ValueError(f"Not a Commons URL: {url!r}")
+
+    if len(u.path) < 2 or u.path[0] != "wiki" or not u.path[1].startswith("File:"):
+        raise ValueError(f"Not a Commons URL: {url!r}")
+
+    return re.sub(r"^File:", "", u.path[1])

--- a/tests/apis/test_wikimedia_url_parser.py
+++ b/tests/apis/test_wikimedia_url_parser.py
@@ -1,0 +1,34 @@
+import pytest
+
+from flickypedia.apis.wikimedia import get_filename_from_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.net",
+        "https://commons.wikimedia.org/",
+        "https://commons.wikimedia.org/wiki/Category:Flickr_images_missing_SDC_creator",
+        "https://commons.wikimedia.org/w/index.php",
+    ],
+)
+def test_it_rejects_non_file_urls(url: str) -> None:
+    with pytest.raises(ValueError):
+        get_filename_from_url(url)
+
+
+@pytest.mark.parametrize(
+    ["url", "filename"],
+    [
+        (
+            "https://commons.wikimedia.org/wiki/File:Portogallo_2007_(1677680909).jpg",
+            "Portogallo_2007_(1677680909).jpg",
+        ),
+        (
+            "https://commons.wikimedia.org/wiki/File:%225_April_2017_-_The_Culture_defense_(34175959031).jpg",
+            '"5_April_2017_-_The_Culture_defense_(34175959031).jpg',
+        ),
+    ],
+)
+def test_it_gets_filename_from_url(url: str, filename: str) -> None:
+    assert get_filename_from_url(url) == filename


### PR DESCRIPTION
This is a little utility function for https://github.com/Flickr-Foundation/flickypedia/issues/331 – the current code can't handle quotes in URLs.