### PR TITLE
Handle mobile Commons URLs in the Wikimedia URL parser

### DIFF
--- a/src/flickypedia/apis/wikimedia/url_parser.py
+++ b/src/flickypedia/apis/wikimedia/url_parser.py
@@ -13,7 +13,7 @@ def get_filename_from_url(url: str) -> str:
     """
     u = hyperlink.DecodedURL.from_text(url)
 
-    if u.host != "commons.wikimedia.org":
+    if u.host not in {"commons.wikimedia.org", "commons.m.wikimedia.org"}:
         raise ValueError(f"Not a Commons URL: {url!r}")
 
     if len(u.path) < 2 or u.path[0] != "wiki" or not u.path[1].startswith("File:"):

--- a/tests/apis/test_wikimedia_url_parser.py
+++ b/tests/apis/test_wikimedia_url_parser.py
@@ -28,6 +28,10 @@ def test_it_rejects_non_file_urls(url: str) -> None:
             "https://commons.wikimedia.org/wiki/File:%225_April_2017_-_The_Culture_defense_(34175959031).jpg",
             '"5_April_2017_-_The_Culture_defense_(34175959031).jpg',
         ),
+        (
+            "https://commons.m.wikimedia.org/wiki/File:%22Christmas_wishes%22_-_Christmas_card._Nellie_Murrell_Collection,_Australia_c._1900s.jpg",
+            '"Christmas_wishes"_-_Christmas_card._Nellie_Murrell_Collection,_Australia_c._1900s.jpg',
+        ),
     ],
 )
 def test_it_gets_filename_from_url(url: str, filename: str) -> None:


### PR DESCRIPTION
I landed on a few mobile URLs from Google; let's make sure we know how to parse those also.