### PR TITLE
Improve the date comparison logic in P571

### DIFF
--- a/src/flickypedia/apis/structured_data/_qualifiers.py
+++ b/src/flickypedia/apis/structured_data/_qualifiers.py
@@ -58,7 +58,7 @@ class QualifierValueTypes:
             "type": Literal["date"],
             "property": str,
             "date": datetime.datetime,
-            "precision": str,
+            "precision": Literal["day", "month", "year"],
         },
     )
 

--- a/src/flickypedia/apis/structured_data/create_structured_data.py
+++ b/src/flickypedia/apis/structured_data/create_structured_data.py
@@ -386,13 +386,15 @@ def create_date_taken_statement(date_taken: DateTaken) -> NewStatement:
     """
     flickr_granularity = date_taken["granularity"]
 
+    precision_lookup: dict[str, Literal["day", "month", "year"]] = {
+        "second": "day",
+        "month": "month",
+        "year": "year",
+        "circa": "year",
+    }
+
     try:
-        wikidata_precision = {
-            "second": "day",
-            "month": "month",
-            "year": "year",
-            "circa": "year",
-        }[flickr_granularity]
+        wikidata_precision = precision_lookup[flickr_granularity]
     except KeyError:
         raise ValueError(f"Unrecognised taken_granularity: {flickr_granularity!r}")
 

--- a/tests/apis/test_wikidata.py
+++ b/tests/apis/test_wikidata.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 import pytest
 
@@ -7,7 +7,10 @@ from flickypedia.apis.structured_data.wikidata import to_wikidata_date_value
 from flickypedia.types.structured_data import DataValueTypes
 
 
-ToWikidateArgs = TypedDict("ToWikidateArgs", {"d": datetime.datetime, "precision": str})
+ToWikidateArgs = TypedDict(
+    "ToWikidateArgs",
+    {"d": datetime.datetime, "precision": Literal["day", "month", "year"]},
+)
 
 
 @pytest.mark.parametrize(
@@ -61,8 +64,3 @@ def test_to_wikidata_date_value(
     kwargs: ToWikidateArgs, expected: DataValueTypes.Time
 ) -> None:
     assert to_wikidata_date_value(**kwargs) == expected
-
-
-def test_to_wikidata_date_value_fails_with_unexpected_precision() -> None:
-    with pytest.raises(ValueError, match="Unrecognised precision"):
-        to_wikidata_date_value(d=datetime.datetime(2023, 10, 12), precision="second")


### PR DESCRIPTION
In particular, don't treat dates as different if they only differ in components beyond the current precision level.

e.g. 2001-02-03 and 2001-01-01 are the same if you're only looking at year-level precision, but not month or day.