### PR TITLE
Add select all feature to photo selection form

### DIFF
--- a/src/flickypedia/uploadr/templates/select_photos/index.html
+++ b/src/flickypedia/uploadr/templates/select_photos/index.html
@@ -38,6 +38,8 @@
       Choose the photos you want:
     </h3>
 
+    <p><a href="#" onclick="selectAll(event)">Select all</p>
+
     <form id="select_photos" action="{{ url_for('select_photos', flickr_url=flickr_url) }}" method="post">
       {{ select_photos_form.hidden_tag() }}
 
@@ -107,6 +109,17 @@
         }
 
         console.log(selectedPhotos);
+      }
+
+      function selectAll(event) {
+          event.preventDefault();
+          const checkboxes = document.querySelectorAll('#select_photos input[type=checkbox]');
+
+          checkboxes.forEach(checkbox => {
+              checkbox.checked = true;
+          });
+
+          highlightSelected();
       }
     </script>
   {% endif %}


### PR DESCRIPTION
Implemented a 'Select All' function in the photo selection form to
enhance user experience. This feature allows users to select all photos
in an album with a single click, significantly reducing effort and
improving efficiency, especially for albums with a large number of
photos.
