### PR TITLE
Make sure we exclude invalid titles with colons and slashes

### DIFF
--- a/src/flickypedia/apis/wikimedia/api.py
+++ b/src/flickypedia/apis/wikimedia/api.py
@@ -412,6 +412,17 @@ class WikimediaApi:
                 "text": "Please remove the filename suffix; it will be added automatically.",
             }
 
+        # Check for illegal characters, as defined by the wgIllegalFileChars
+        # setting -- these are blocked by the Upload Wizard.
+        #
+        # See https://www.mediawiki.org/wiki/Manual:$wgIllegalFileChars
+        # See https://til.alexwlchan.net/wmc-allowed-title-characters/
+        if any(char in base_name for char in ":/\\"):
+            return {
+                "result": "invalid",
+                "text": "This title is invalid. Make sure to remove characters like square brackets, colons, slashes, comparison operators, pipes and curly brackets.",
+            }
+
         # Check for other pages with this title -- are we going to
         # duplicate an existing file?
         #

--- a/tests/apis/test_wikimedia.py
+++ b/tests/apis/test_wikimedia.py
@@ -321,6 +321,20 @@ def test_validate_title_rejects_image_suffix(
     }
 
 
+@pytest.mark.parametrize(
+    "title", ["This:is:a:title:with:colons", "This/is\\a/title\\with/slashes"]
+)
+def test_validate_title_rejects_illegal_chars(
+    wikimedia_api: WikimediaApi, title: str
+) -> None:
+    result = wikimedia_api.validate_title(title=f"File:{title}.jpg")
+
+    assert result == {
+        "result": "invalid",
+        "text": "This title is invalid. Make sure to remove characters like square brackets, colons, slashes, comparison operators, pipes and curly brackets.",
+    }
+
+
 def test_find_matching_categories(wikimedia_api: WikimediaApi) -> None:
     result = wikimedia_api.find_matching_categories(query="a")
 


### PR DESCRIPTION
This is a bug that's been reported by a couple of people on the Talk page – the Upload Wizard will catch these invalid titles, but we don't. It took a bit of debugging to work out what the Upload Wizard is doing here, but I managed to track it down in the end. :D