### PR TITLE
Add a comment to the initial upload

### DIFF
--- a/src/flickypedia/apis/wikimedia/api.py
+++ b/src/flickypedia/apis/wikimedia/api.py
@@ -119,6 +119,7 @@ class WikimediaApi:
                 "filename": filename,
                 "url": original_url,
                 "text": text,
+                "comment": "Copied photo from Flickr using Flickypedia",
             },
             # Note: this can fail with an httpx.ReadTimeout error with
             # the default timeout, so we increase it.


### PR DESCRIPTION
This improves how the initial upload appears in the file's history tab. Previously nothing was displayed there, which looked a bit odd.