### PR TITLE
Add an empty description field to the Wikitext template

### DIFF
--- a/src/flickypedia/apis/wikitext.py
+++ b/src/flickypedia/apis/wikitext.py
@@ -46,6 +46,7 @@ def create_wikitext(
         information = (
             "=={{int:filedesc}}==\n"
             "{{Information\n"
+            "|description=\n"
             "|other fields=\n"
             "{{Flickr Tags 2|%s}}\n"
             "}}"
@@ -53,7 +54,9 @@ def create_wikitext(
     else:
         information = (
             "=={{int:filedesc}}==\n"
-            "{{Information}}"
+            "{{Information\n"
+            "|description=\n"
+            "}}"
         )
     # fmt: on
 

--- a/tests/apis/test_wikitext.py
+++ b/tests/apis/test_wikitext.py
@@ -27,6 +27,7 @@ def test_create_wikitext_for_photo() -> None:
         """
         =={{int:filedesc}}==
         {{Information
+        |description=
         |other fields=
         {{Flickr Tags 2|mascot|chiefbert|germanshepherd|stationelizabethcity|weekinthelife2017|ninabowen|d5|midatlantic|northcarolina|elizabethcity|explosivedetectiondog|unitedstates|us}}
         }}
@@ -61,6 +62,7 @@ def test_adds_categories_to_wikitext() -> None:
         """
         =={{int:filedesc}}==
         {{Information
+        |description=
         |other fields=
         {{Flickr Tags 2|mascot|chiefbert|germanshepherd|stationelizabethcity|weekinthelife2017|ninabowen|d5|midatlantic|northcarolina|elizabethcity|explosivedetectiondog|unitedstates|us}}
         }}
@@ -96,7 +98,7 @@ def test_adds_location_to_wikitext() -> None:
         new_categories=[],
     )
 
-    assert "{{Information}}\n{{Location}}\n" in wikitext
+    assert "{{Information\n|description=\n}}\n{{Location}}\n" in wikitext
 
 
 def test_it_skips_tags_if_none_on_photo() -> None:
@@ -110,7 +112,7 @@ def test_it_skips_tags_if_none_on_photo() -> None:
     )
 
     assert "Flickr Tags 2" not in wikitext
-    assert "{{Information}}" in wikitext
+    assert "{{Information\n|description=\n}}" in wikitext
 
 
 config = create_config(data_directory=pathlib.Path("data"))


### PR DESCRIPTION
This is based on some feedback on the Flickypedia talk page – just making it a bit more obvious this should happen.