### PR TITLE
Fix some bugs in the Wikimedia API handling code

### DIFF
--- a/src/flickypedia/apis/wikimedia/api.py
+++ b/src/flickypedia/apis/wikimedia/api.py
@@ -720,6 +720,8 @@ class WikimediaApi:
     def get_wikitext(self, filename: str) -> str:
         """
         Return the Wikitext for this page, if it exists.
+
+        See https://www.mediawiki.org/wiki/API:Parsing_wikitext
         """
         assert filename.startswith("File:")
 
@@ -734,6 +736,8 @@ class WikimediaApi:
         except UnknownWikimediaApiException as exc:
             if exc.code == "missingtitle":
                 raise MissingFileException(filename)
+            else:
+                raise
 
         text = resp["parse"]["text"]["*"]
         assert isinstance(text, str)

--- a/src/flickypedia/apis/wikimedia/api.py
+++ b/src/flickypedia/apis/wikimedia/api.py
@@ -523,9 +523,7 @@ class WikimediaApi:
 
         for text_elem in xml.findall(".//Text", namespaces=namespaces):
             this_filename = text_elem.text
-
-            if this_filename is None:
-                continue
+            assert this_filename is not None
 
             if this_filename.lower() == title.lower():
                 return {

--- a/tests/apis/test_wikimedia.py
+++ b/tests/apis/test_wikimedia.py
@@ -416,6 +416,14 @@ def test_get_image_url_for_missing_file(wikimedia_api: WikimediaApi) -> None:
         wikimedia_api.get_image_url(filename="File:DefinitelyDoesNotExist.jpg")
 
 
+def test_get_file_without_structured_data_is_empty(wikimedia_api: WikimediaApi) -> None:
+    """
+    If a file exists on Commons but it doesn't have any structured data,
+    we should get an empty dict back.
+    """
+    assert wikimedia_api.get_structured_data(filename="Nyungw.jpg") == {}
+
+
 def test_get_structured_data_for_missing_file(wikimedia_api: WikimediaApi) -> None:
     with pytest.raises(MissingFileException):
         wikimedia_api.get_structured_data(filename="DefinitelyDoesNotExist.jpg")

--- a/tests/apis/test_wikimedia.py
+++ b/tests/apis/test_wikimedia.py
@@ -404,6 +404,11 @@ def test_get_wikitext_for_missing_file(wikimedia_api: WikimediaApi) -> None:
         wikimedia_api.get_wikitext(filename="File:DefinitelyDoesNotExist.jpg")
 
 
+def test_bad_filename_is_exception(wikimedia_api: WikimediaApi) -> None:
+    with pytest.raises(UnknownWikimediaApiException):
+        wikimedia_api.get_wikitext(filename="File:")
+
+
 def test_get_image_url(wikimedia_api: WikimediaApi) -> None:
     actual = wikimedia_api.get_image_url(filename="File:Example.jpg")
     expected = "https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg"

--- a/tests/fixtures/cassettes/test_bad_filename_is_exception.yml
+++ b/tests/fixtures/cassettes/test_bad_filename_is_exception.yml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - commons.wikimedia.org
+      user-agent:
+      - python-httpx/0.25.1
+    method: GET
+    uri: https://commons.wikimedia.org/w/api.php?action=parse&page=File%3A&prop=text&format=json
+  response:
+    content: '{"error":{"code":"invalidtitle","info":"Bad title \"File:\".","*":"See
+      https://commons.wikimedia.org/w/api.php for API usage. Subscribe to the mediawiki-api-announce
+      mailing list at &lt;https://lists.wikimedia.org/postorius/lists/mediawiki-api-announce.lists.wikimedia.org/&gt;
+      for notice of API deprecations and breaking changes."},"servedby":"mw1402"}'
+    headers:
+      accept-ranges:
+      - bytes
+      age:
+      - '2'
+      cache-control:
+      - private, must-revalidate, max-age=0
+      content-disposition:
+      - inline; filename=api-result.json
+      content-length:
+      - '353'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Feb 2024 11:20:03 GMT
+      mediawiki-api-error:
+      - invalidtitle
+      nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      report-to:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      server:
+      - mw1402.eqiad.wmnet
+      server-timing:
+      - cache;desc="pass", host;desc="cp3068"
+      set-cookie:
+      - WMF-Last-Access=26-Feb-2024;Path=/;HttpOnly;secure;Expires=Fri, 29 Mar 2024
+        00:00:00 GMT
+      - GeoIP=GB:ENG:Ipswich:52.06:1.16:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;Max-Age=3600
+      strict-transport-security:
+      - max-age=106384710; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-cache:
+      - cp3068 miss, cp3068 pass
+      x-cache-status:
+      - pass
+      x-client-ip:
+      - 92.30.89.207
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/fixtures/cassettes/test_get_file_without_structured_data_is_empty.yml
+++ b/tests/fixtures/cassettes/test_get_file_without_structured_data_is_empty.yml
@@ -1,0 +1,65 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - commons.wikimedia.org
+      user-agent:
+      - python-httpx/0.25.1
+    method: GET
+    uri: https://commons.wikimedia.org/w/api.php?action=wbgetentities&sites=commonswiki&titles=File%3ANyungw.jpg&format=json
+  response:
+    content: '{"entities":{"M1004":{"id":"M1004","missing":""}},"success":1}'
+    headers:
+      accept-ranges:
+      - bytes
+      age:
+      - '0'
+      cache-control:
+      - private, must-revalidate, max-age=0
+      content-disposition:
+      - inline; filename=api-result.json
+      content-length:
+      - '62'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Feb 2024 11:07:04 GMT
+      nel:
+      - '{ "report_to": "wm_nel", "max_age": 604800, "failure_fraction": 0.05, "success_fraction":
+        0.0}'
+      report-to:
+      - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
+        }] }'
+      server:
+      - mw1400.eqiad.wmnet
+      server-timing:
+      - cache;desc="pass", host;desc="cp3068"
+      set-cookie:
+      - WMF-Last-Access=26-Feb-2024;Path=/;HttpOnly;secure;Expires=Fri, 29 Mar 2024
+        00:00:00 GMT
+      - GeoIP=GB:ENG:Ipswich:52.06:1.16:v4; Path=/; secure; Domain=.wikimedia.org
+      - NetworkProbeLimit=0.001;Path=/;Secure;Max-Age=3600
+      strict-transport-security:
+      - max-age=106384710; includeSubDomains; preload
+      vary:
+      - Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie
+      x-cache:
+      - cp3068 miss, cp3068 pass
+      x-cache-status:
+      - pass
+      x-client-ip:
+      - 92.30.89.207
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
* Distinguish between "this file doesn't exist" and "this file has no SDC"
* Make sure we throw if we get an unexpected error looking up Wikitext
* Add an assertion for the type checker