### PR TITLE
Handle multiple instances of P973 Described at URL

### DIFF
--- a/tests/backfillr/test_flickr_matcher.py
+++ b/tests/backfillr/test_flickr_matcher.py
@@ -285,7 +285,7 @@ def test_ambiguous_qualifier_is_error() -> None:
         find_flickr_photo_id_from_sdc(sdc)
 
 
-def test_it_works() -> None:
+def test_it_handles_a_some_value_string() -> None:
     # M52096071 = Alexander Isak (training 2016, cropped 1).jpg
     # Retrieved 7 May 2024
     #
@@ -294,5 +294,16 @@ def test_it_works() -> None:
     # but it was breaking some code that expected there to be a datavalue
     # there instead.
     sdc = get_statement_fixture("M52096071_P7482.json")
+
+    assert find_flickr_photo_id_from_sdc(sdc) is None
+
+
+def test_handles_multiple_described_at_urls() -> None:
+    # M113422 = RMS Lusitania deck plans.jpg
+    # Retrieved 7 May 2024
+    #
+    # This has multiple instances of the P973 qualifier, but none of them
+    # are Flickr URLs so we don't actually care about them.
+    sdc = get_statement_fixture("M113422_P7482.json")
 
     assert find_flickr_photo_id_from_sdc(sdc) is None

--- a/tests/fixtures/structured_data/existing/M113422_P7482.json
+++ b/tests/fixtures/structured_data/existing/M113422_P7482.json
@@ -1,0 +1,47 @@
+{
+  "P7482": [
+	{
+	  "type": "statement",
+	  "mainsnak": {
+		"property": "P7482",
+		"snaktype": "value",
+		"datavalue": {
+		  "type": "wikibase-entityid",
+		  "value": {
+			"entity-type": "item",
+			"id": "Q74228490",
+			"numeric-id": 74228490
+		  }
+		},
+		"hash": "b82dd47222a210c6dc1f428b693c2fbf7b0e0d6e"
+	  },
+	  "qualifiers-order": [
+		"P973"
+	  ],
+	  "qualifiers": {
+		"P973": [
+		  {
+			"property": "P973",
+			"snaktype": "value",
+			"datavalue": {
+			  "type": "string",
+			  "value": "https://hdl.handle.net/2027/mdp.39015084574220?urlappend=%3Bseq=276%3Bownerid=13510798902007342-316"
+			},
+			"hash": "6ed8da195e311ffef360e978c9e591fb063a570b"
+		  },
+		  {
+			"property": "P973",
+			"snaktype": "value",
+			"datavalue": {
+			  "type": "string",
+			  "value": "https://hdl.handle.net/2027/mdp.39015084574220?urlappend=%3Bseq=277%3Bownerid=13510798902007342-317"
+			},
+			"hash": "3b9c8753d8adfe889bab0f94e8084aa9c2c6a3a6"
+		  }
+		]
+	  },
+	  "id": "M11342240$7b2954b5-486c-39b8-9d24-c955192b0a65",
+	  "rank": "normal"
+	}
+  ]
+}


### PR DESCRIPTION
This fixes some of the issues I had getting Flickr IDs from the SDC snapshot today – mostly files with multiple "described at" URLs, but they weren't Flickr URLs so I'm not too fussed.