### PR TITLE
A few more improvements to Backfillr Bot

### DIFF
--- a/src/flickypedia/apis/structured_data/__init__.py
+++ b/src/flickypedia/apis/structured_data/__init__.py
@@ -8,7 +8,7 @@ from .create_structured_data import (
     create_posted_to_flickr_statement,
     create_sdc_claims_for_existing_flickr_photo,
     create_sdc_claims_for_new_flickr_photo,
-    create_source_data_for_photo,
+    create_source_statement,
 )
 
 __all__ = [
@@ -21,5 +21,5 @@ __all__ = [
     "create_posted_to_flickr_statement",
     "create_sdc_claims_for_existing_flickr_photo",
     "create_sdc_claims_for_new_flickr_photo",
-    "create_source_data_for_photo",
+    "create_source_statement",
 ]

--- a/src/flickypedia/apis/structured_data/create_structured_data.py
+++ b/src/flickypedia/apis/structured_data/create_structured_data.py
@@ -158,14 +158,14 @@ def create_copyright_status_statement(license_id: str) -> NewStatement:
         raise ValueError(f"Unable to map a copyright status for license {license_id!r}")
 
 
-def create_source_data_for_photo(
+def create_source_statement(
     photo_id: str,
     photo_url: str,
     original_url: str | None,
     retrieved_at: datetime.datetime | None,
 ) -> NewStatement:
     """
-    Create a structured data statement for a Flickr photo.
+    Create a structured data statement for the "source" statement.
     """
     qualifier_values: list[QualifierValues] = [
         {
@@ -472,7 +472,7 @@ def _create_sdc_claims_for_flickr_photo(
         if mode == "new_photo":  # pragma: no cover
             raise
 
-        source_statement = create_source_data_for_photo(
+        source_statement = create_source_statement(
             photo_id=photo["id"],
             photo_url=photo["url"],
             original_url=None,
@@ -481,7 +481,7 @@ def _create_sdc_claims_for_flickr_photo(
 
         statements.append(source_statement)
     else:
-        source_statement = create_source_data_for_photo(
+        source_statement = create_source_statement(
             photo_id=photo["id"],
             photo_url=photo["url"],
             original_url=original_size["source"],

--- a/tests/apis/test_create_structured_data.py
+++ b/tests/apis/test_create_structured_data.py
@@ -20,7 +20,7 @@ from flickypedia.apis.structured_data import (
     create_posted_to_flickr_statement,
     create_sdc_claims_for_existing_flickr_photo,
     create_sdc_claims_for_new_flickr_photo,
-    create_source_data_for_photo,
+    create_source_statement,
 )
 from flickypedia.types.flickr import SinglePhotoData
 from flickypedia.types.structured_data import NewClaims, NewStatement
@@ -106,8 +106,8 @@ def test_create_copyright_status_statement(license_id: str, filename: str) -> No
     assert result == expected
 
 
-def test_create_source_data_for_photo() -> None:
-    result = create_source_data_for_photo(
+def test_create_source_statement() -> None:
+    result = create_source_statement(
         photo_id="53248015596",
         photo_url="https://www.flickr.com/photos/199246608@N02/53248015596/",
         original_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",
@@ -118,8 +118,8 @@ def test_create_source_data_for_photo() -> None:
     assert result == expected
 
 
-def test_create_source_data_without_retrieved_at() -> None:
-    result = create_source_data_for_photo(
+def test_create_source_statement_without_retrieved_at() -> None:
+    result = create_source_statement(
         photo_id="53248015596",
         photo_url="https://www.flickr.com/photos/199246608@N02/53248015596/",
         original_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",

--- a/tests/backfillr/test_actions.py
+++ b/tests/backfillr/test_actions.py
@@ -390,7 +390,12 @@ def test_a_null_creator_statement_is_replaced() -> None:
     ]
 
 
-def test_a_creator_is_replaced_if_numeric_id_in_alias() -> None:
+def test_it_does_nothing_if_creator_differs_only_in_url() -> None:
+    """
+    If the statements are the same, except the URL on WMC uses
+    the numeric ID and the URL on Flickr uses the pathalias, we
+    can leave the URL on WMC as-is.
+    """
     existing_statement: ExistingStatement = {
         "type": "statement",
         "mainsnak": {
@@ -471,9 +476,7 @@ def test_a_creator_is_replaced_if_numeric_id_in_alias() -> None:
     assert actions == [
         {
             "property_id": "P170",
-            "action": "replace_statement",
-            "statement_id": "M34597$10AA104E-CFBD-44C2-8D43-FF8C48FE428A",
-            "statement": new_statement,
+            "action": "do_nothing",
         }
     ]
 
@@ -546,4 +549,116 @@ def test_it_does_nothing_for_mismatched_creator() -> None:
 
     assert create_actions(existing_sdc, new_sdc) == [
         {"action": "unknown", "property_id": "P170"}
+    ]
+
+
+def test_it_ignores_extra_roles_in_creator_if_otherwise_equivalent():
+    # Based on https://commons.wikimedia.org/wiki/File:Programme_(1919)_(14783412743).jpg
+    # Retrieved 9 May 2024
+    existing_sdc: ExistingClaims = {
+        "P170": [
+            {
+                "type": "statement",
+                "mainsnak": {
+                    "property": "P170",
+                    "snaktype": "somevalue",
+                    "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
+                },
+                "qualifiers-order": ["P3831", "P2093", "P3267", "P2699"],
+                "qualifiers": {
+                    "P3831": [
+                        {
+                            "property": "P3831",
+                            "snaktype": "value",
+                            "datavalue": {
+                                "type": "wikibase-entityid",
+                                "value": {
+                                    "entity-type": "item",
+                                    "id": "Q33231",
+                                    "numeric-id": 33231,
+                                },
+                            },
+                            "hash": "c5e04952fd00011abf931be1b701f93d9e6fa5d7",
+                        }
+                    ],
+                    "P2093": [
+                        {
+                            "property": "P2093",
+                            "snaktype": "value",
+                            "datavalue": {
+                                "type": "string",
+                                "value": "Internet Archive Book Images",
+                            },
+                            "hash": "407646c600d296f66b9b08acf1e09bd36814c83d",
+                        }
+                    ],
+                    "P3267": [
+                        {
+                            "property": "P3267",
+                            "snaktype": "value",
+                            "datavalue": {"type": "string", "value": "126377022@N07"},
+                            "hash": "19d030d2329f5e7b395a6e0a2df538053fa4ec11",
+                        }
+                    ],
+                    "P2699": [
+                        {
+                            "property": "P2699",
+                            "snaktype": "value",
+                            "datavalue": {
+                                "type": "string",
+                                "value": "https://www.flickr.com/people/126377022@N07",
+                            },
+                            "hash": "4d79b9f1f095fec5270b5c5ee9f549602270135d",
+                        }
+                    ],
+                },
+                "id": "M43417962$70B1AA68-B675-4EBA-8A1E-A3F5F1243944",
+                "rank": "normal",
+            }
+        ],
+    }
+    new_sdc: NewClaims = {
+        "claims": [
+            {
+                "mainsnak": {"snaktype": "somevalue", "property": "P170"},
+                "qualifiers": {
+                    "P2093": [
+                        {
+                            "datavalue": {
+                                "value": "Internet Archive Book Images",
+                                "type": "string",
+                            },
+                            "property": "P2093",
+                            "snaktype": "value",
+                        }
+                    ],
+                    "P2699": [
+                        {
+                            "datavalue": {
+                                "value": "https://www.flickr.com/people/internetarchivebookimages/",
+                                "type": "string",
+                            },
+                            "property": "P2699",
+                            "snaktype": "value",
+                        }
+                    ],
+                    "P3267": [
+                        {
+                            "datavalue": {"value": "126377022@N07", "type": "string"},
+                            "property": "P3267",
+                            "snaktype": "value",
+                        }
+                    ],
+                },
+                "qualifiers-order": ["P3267", "P2093", "P2699"],
+                "type": "statement",
+            },
+        ]
+    }
+
+    assert create_actions(existing_sdc, new_sdc) == [
+        {
+            "property_id": "P170",
+            "action": "do_nothing",
+        }
     ]

--- a/tests/uploadr/templates/prepare_info/test_structured_data_preview.py
+++ b/tests/uploadr/templates/prepare_info/test_structured_data_preview.py
@@ -18,7 +18,7 @@ from flickypedia.apis.structured_data import (
     create_license_statement,
     create_location_statement,
     create_posted_to_flickr_statement,
-    create_source_data_for_photo,
+    create_source_statement,
 )
 from flickypedia.types.structured_data import NewStatement
 
@@ -133,7 +133,7 @@ def test_shows_copyright_status(app: Flask, vcr_cassette: str) -> None:
 
 
 def test_shows_source_data(app: Flask, vcr_cassette: str) -> None:
-    source_claim = create_source_data_for_photo(
+    source_claim = create_source_statement(
         photo_id="53248015596",
         photo_url="https://www.flickr.com/photos/199246608@N02/53248015596/",
         original_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",


### PR DESCRIPTION
In particular we can be a bit more lenient with the existing data, and recognise certain formats like a P170 Creator statement that already contains the Flickr username can be upgraded to the full Flickr user statement.