### PR TITLE
Replace a Creator statement which just contains the pathalias

### DIFF
--- a/src/flickypedia/backfillr/actions.py
+++ b/src/flickypedia/backfillr/actions.py
@@ -51,7 +51,7 @@ Action = DoNothing | AddMissing | AddQualifiers | ReplaceStatement | Unknown
 
 
 def create_actions(
-    existing_sdc: ExistingClaims, new_sdc: NewClaims, user: FlickrUser | None = None
+    existing_sdc: ExistingClaims, new_sdc: NewClaims, user: FlickrUser
 ) -> list[Action]:
     actions: list[Action] = []
 
@@ -105,7 +105,7 @@ def create_actions(
             #
             # We can replace this with a richer Creator statement, which will
             # include this pathalias but also other information.
-            if property_id == WP.Creator and user is not None:
+            if property_id == WP.Creator and user["path_alias"] is not None:
                 pathalias_statement = create_author_name_statement(
                     author_name=user["path_alias"]
                 )

--- a/src/flickypedia/backfillr/actions.py
+++ b/src/flickypedia/backfillr/actions.py
@@ -51,13 +51,13 @@ Action = DoNothing | AddMissing | AddQualifiers | ReplaceStatement | Unknown
 
 
 def create_actions(
-    existing_sdc: ExistingClaims, new_sdc: NewClaims, user: FlickrUser
+    existing_claims: ExistingClaims, new_claims: NewClaims, user: FlickrUser
 ) -> list[Action]:
     actions: list[Action] = []
 
-    for new_statement in new_sdc["claims"]:
+    for new_statement in new_claims["claims"]:
         property_id = new_statement["mainsnak"]["property"]
-        existing_statements = existing_sdc.get(property_id, [])
+        existing_statements = existing_claims.get(property_id, [])
 
         # If there are no statements with this property on the
         # existing SDC, then we just need to add it.

--- a/tests/backfillr/test_actions.py
+++ b/tests/backfillr/test_actions.py
@@ -1,3 +1,4 @@
+from flickr_photos_api import FlickrApi
 import pytest
 
 from flickypedia.backfillr.actions import create_actions
@@ -813,6 +814,78 @@ def test_it_skips_an_unrecognised_author_name(author_name: str) -> None:
     new_claims: NewClaims = {"claims": [creator_statement]}
 
     assert create_actions(existing_claims, new_claims) == [
+        {
+            "property_id": "P170",
+            "action": "unknown",
+        }
+    ]
+
+
+def test_it_replaces_an_author_pathalias(flickr_api: FlickrApi) -> None:
+    user = flickr_api.get_user(user_id="9751269@N07")
+
+    existing_claims: ExistingClaims = {
+        "P170": [
+            {
+                "type": "statement",
+                "mainsnak": {
+                    "property": "P170",
+                    "snaktype": "somevalue",
+                    "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
+                },
+                "qualifiers-order": ["P2093"],
+                "qualifiers": {
+                    "P2093": [
+                        {
+                            "property": "P2093",
+                            "snaktype": "value",
+                            "datavalue": {"type": "string", "value": "dwhartwig"},
+                            "hash": "a0c63c1fe81dff8f300427326a19939afb65ad95",
+                        }
+                    ]
+                },
+                "id": "M108119123$1B7C1641-4F9A-4B73-B059-190083E2AC9F",
+                "rank": "normal",
+            }
+        ],
+    }
+    new_claims: NewClaims = {
+        "claims": [
+            {
+                "mainsnak": {"snaktype": "somevalue", "property": "P170"},
+                "qualifiers": {
+                    "P2093": [
+                        {
+                            "datavalue": {"value": "Daniel Hartwig", "type": "string"},
+                            "property": "P2093",
+                            "snaktype": "value",
+                        }
+                    ],
+                    "P2699": [
+                        {
+                            "datavalue": {
+                                "value": "https://www.flickr.com/people/dwhartwig/",
+                                "type": "string",
+                            },
+                            "property": "P2699",
+                            "snaktype": "value",
+                        }
+                    ],
+                    "P3267": [
+                        {
+                            "datavalue": {"value": "9751269@N07", "type": "string"},
+                            "property": "P3267",
+                            "snaktype": "value",
+                        }
+                    ],
+                },
+                "qualifiers-order": ["P3267", "P2093", "P2699"],
+                "type": "statement",
+            },
+        ]
+    }
+
+    assert create_actions(existing_claims, new_claims, user) != [
         {
             "property_id": "P170",
             "action": "unknown",

--- a/tests/backfillr/test_actions.py
+++ b/tests/backfillr/test_actions.py
@@ -31,16 +31,16 @@ def test_missing_statement_is_added() -> None:
         "type": "statement",
     }
 
-    existing_sdc: ExistingClaims = {}
-    new_sdc: NewClaims = {"claims": [statement]}
+    existing_claims: ExistingClaims = {}
+    new_claims: NewClaims = {"claims": [statement]}
 
-    assert create_actions(existing_sdc, new_sdc, user=null_user) == [
+    assert create_actions(existing_claims, new_claims, user=null_user) == [
         {"property_id": "P12120", "action": "add_missing", "statement": statement}
     ]
 
 
 def test_equivalent_statement_is_no_op() -> None:
-    existing_sdc: ExistingClaims = {
+    existing_claims: ExistingClaims = {
         "P170": [
             {
                 "id": "M138765382$505642FD-63FB-4397-8AC5-F48E59DE3142",
@@ -85,7 +85,7 @@ def test_equivalent_statement_is_no_op() -> None:
         ]
     }
 
-    new_sdc: NewClaims = {
+    new_claims: NewClaims = {
         "claims": [
             {
                 "mainsnak": {"property": "P170", "snaktype": "somevalue"},
@@ -121,13 +121,13 @@ def test_equivalent_statement_is_no_op() -> None:
         ]
     }
 
-    assert create_actions(existing_sdc, new_sdc, user=null_user) == [
+    assert create_actions(existing_claims, new_claims, user=null_user) == [
         {"property_id": "P170", "action": "do_nothing"}
     ]
 
 
 def test_adds_qualifiers_if_existing_are_subset_of_new() -> None:
-    existing_sdc: ExistingClaims = {
+    existing_claims: ExistingClaims = {
         "P7482": [
             {
                 "id": "M138765382$18DE2E71-EFFC-42CA-B466-83838347748E",
@@ -211,9 +211,9 @@ def test_adds_qualifiers_if_existing_are_subset_of_new() -> None:
         "type": "statement",
     }
 
-    new_sdc: NewClaims = {"claims": [statement]}
+    new_claims: NewClaims = {"claims": [statement]}
 
-    assert create_actions(existing_sdc, new_sdc, user=null_user) == [
+    assert create_actions(existing_claims, new_claims, user=null_user) == [
         {
             "property_id": "P7482",
             "action": "add_qualifiers",
@@ -224,7 +224,7 @@ def test_adds_qualifiers_if_existing_are_subset_of_new() -> None:
 
 
 def test_does_not_qualifiers_if_existing_are_disjoint_from_new() -> None:
-    existing_sdc: ExistingClaims = {
+    existing_claims: ExistingClaims = {
         "P7482": [
             {
                 "id": "M138765382$18DE2E71-EFFC-42CA-B466-83838347748E",
@@ -321,7 +321,7 @@ def test_does_not_qualifiers_if_existing_are_disjoint_from_new() -> None:
 
     new_claims: NewClaims = {"claims": [statement]}
 
-    assert create_actions(existing_sdc, new_claims, user=null_user) == [
+    assert create_actions(existing_claims, new_claims, user=null_user) == [
         {
             "property_id": "P7482",
             "action": "unknown",

--- a/tests/backfillr/test_actions.py
+++ b/tests/backfillr/test_actions.py
@@ -1,13 +1,24 @@
-from flickr_photos_api import FlickrApi
+from flickr_photos_api import FlickrApi, User as FlickrUser
 import pytest
 
 from flickypedia.backfillr.actions import create_actions
+from flickypedia.apis.structured_data import create_flickr_creator_statement
 from flickypedia.types.structured_data import (
     ExistingClaims,
     ExistingStatement,
     NewClaims,
     NewStatement,
 )
+
+
+null_user: FlickrUser = {
+    "id": "-1",
+    "path_alias": None,
+    "username": "example",
+    "realname": None,
+    "photos_url": "https://www.flickr.com/photos/-1",
+    "profile_url": "https://www.flickr.com/people/-1",
+}
 
 
 def test_missing_statement_is_added() -> None:
@@ -23,9 +34,7 @@ def test_missing_statement_is_added() -> None:
     existing_sdc: ExistingClaims = {}
     new_sdc: NewClaims = {"claims": [statement]}
 
-    actions = create_actions(existing_sdc, new_sdc)
-
-    assert actions == [
+    assert create_actions(existing_sdc, new_sdc, user=null_user) == [
         {"property_id": "P12120", "action": "add_missing", "statement": statement}
     ]
 
@@ -112,9 +121,9 @@ def test_equivalent_statement_is_no_op() -> None:
         ]
     }
 
-    actions = create_actions(existing_sdc, new_sdc)
-
-    assert actions == [{"property_id": "P170", "action": "do_nothing"}]
+    assert create_actions(existing_sdc, new_sdc, user=null_user) == [
+        {"property_id": "P170", "action": "do_nothing"}
+    ]
 
 
 def test_adds_qualifiers_if_existing_are_subset_of_new() -> None:
@@ -204,9 +213,7 @@ def test_adds_qualifiers_if_existing_are_subset_of_new() -> None:
 
     new_sdc: NewClaims = {"claims": [statement]}
 
-    actions = create_actions(existing_sdc, new_sdc)
-
-    assert actions == [
+    assert create_actions(existing_sdc, new_sdc, user=null_user) == [
         {
             "property_id": "P7482",
             "action": "add_qualifiers",
@@ -312,11 +319,9 @@ def test_does_not_qualifiers_if_existing_are_disjoint_from_new() -> None:
         "type": "statement",
     }
 
-    new_sdc: NewClaims = {"claims": [statement]}
+    new_claims: NewClaims = {"claims": [statement]}
 
-    actions = create_actions(existing_sdc, new_sdc)
-
-    assert actions == [
+    assert create_actions(existing_sdc, new_claims, user=null_user) == [
         {
             "property_id": "P7482",
             "action": "unknown",
@@ -324,7 +329,7 @@ def test_does_not_qualifiers_if_existing_are_disjoint_from_new() -> None:
     ]
 
 
-def test_a_null_creator_statement_is_replaced() -> None:
+def test_a_null_creator_statement_is_replaced(flickr_api: FlickrApi) -> None:
     existing_statement: ExistingStatement = {
         "type": "statement",
         "mainsnak": {
@@ -346,145 +351,82 @@ def test_a_null_creator_statement_is_replaced() -> None:
         "id": "M26828$E5B1DA53-7604-4B6F-B07A-21BC098CEEC9",
         "rank": "normal",
     }
-    statement: NewStatement = {
-        "mainsnak": {"snaktype": "somevalue", "property": "P170"},
-        "qualifiers": {
-            "P2093": [
-                {
-                    "datavalue": {"value": "StrangeInterlude", "type": "string"},
-                    "property": "P2093",
-                    "snaktype": "value",
-                }
-            ],
-            "P2699": [
-                {
-                    "datavalue": {
-                        "value": "https://www.flickr.com/people/strangeinterlude/",
-                        "type": "string",
-                    },
-                    "property": "P2699",
-                    "snaktype": "value",
-                }
-            ],
-            "P3267": [
-                {
-                    "datavalue": {"value": "44124472424@N01", "type": "string"},
-                    "property": "P3267",
-                    "snaktype": "value",
-                }
-            ],
-        },
-        "qualifiers-order": ["P3267", "P2093", "P2699"],
-        "type": "statement",
-    }
+    existing_claims: ExistingClaims = {"P170": [existing_statement]}
 
-    existing_sdc: ExistingClaims = {"P170": [existing_statement]}
-    new_sdc: NewClaims = {"claims": [statement]}
+    user = flickr_api.get_user(user_id="44124472424@N01")
+    new_statement = create_flickr_creator_statement(user)
+    new_claims: NewClaims = {"claims": [new_statement]}
 
-    actions = create_actions(existing_sdc, new_sdc)
-
-    assert actions == [
+    assert create_actions(existing_claims, new_claims, user) == [
         {
             "property_id": "P170",
             "action": "replace_statement",
-            "statement_id": "M26828$E5B1DA53-7604-4B6F-B07A-21BC098CEEC9",
-            "statement": statement,
+            "statement_id": existing_statement["id"],
+            "statement": new_statement,
         }
     ]
 
 
-def test_it_does_nothing_if_creator_differs_only_in_url() -> None:
+def test_it_does_nothing_if_creator_differs_only_in_url(flickr_api: FlickrApi) -> None:
     """
     If the statements are the same, except the URL on WMC uses
     the numeric ID and the URL on Flickr uses the pathalias, we
     can leave the URL on WMC as-is.
     """
-    existing_statement: ExistingStatement = {
-        "type": "statement",
-        "mainsnak": {
-            "property": "P170",
-            "snaktype": "somevalue",
-            "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
-        },
-        "qualifiers-order": ["P3267", "P2093", "P2699"],
-        "qualifiers": {
-            "P3267": [
-                {
-                    "property": "P3267",
-                    "snaktype": "value",
-                    "datavalue": {"type": "string", "value": "84108876@N00"},
-                    "hash": "fa5d6acd35ca6e50077b15e3c224124df6e28595",
-                }
-            ],
-            "P2093": [
-                {
-                    "property": "P2093",
-                    "snaktype": "value",
-                    "datavalue": {"type": "string", "value": "Jason Pratt"},
-                    "hash": "5208955c9216bddf416e4c58ce5a13ce1ab8d3fb",
-                }
-            ],
-            "P2699": [
-                {
-                    "property": "P2699",
-                    "snaktype": "value",
-                    "datavalue": {
-                        "type": "string",
-                        "value": "https://www.flickr.com/people/84108876@N00",
-                    },
-                    "hash": "0a168876994e47b9028659a4d67e692138556291",
-                }
-            ],
-        },
-        "id": "M34597$10AA104E-CFBD-44C2-8D43-FF8C48FE428A",
-        "rank": "normal",
-    }
-    new_statement: NewStatement = {
-        "mainsnak": {"snaktype": "somevalue", "property": "P170"},
-        "qualifiers": {
-            "P2093": [
-                {
-                    "datavalue": {"value": "Jason Pratt", "type": "string"},
-                    "property": "P2093",
-                    "snaktype": "value",
-                }
-            ],
-            "P2699": [
-                {
-                    "datavalue": {
-                        "value": "https://www.flickr.com/people/jasonpratt/",
-                        "type": "string",
-                    },
-                    "property": "P2699",
-                    "snaktype": "value",
-                }
-            ],
-            "P3267": [
-                {
-                    "datavalue": {"value": "84108876@N00", "type": "string"},
-                    "property": "P3267",
-                    "snaktype": "value",
-                }
-            ],
-        },
-        "qualifiers-order": ["P3267", "P2093", "P2699"],
-        "type": "statement",
+    existing_claims: ExistingClaims = {
+        "P170": [
+            {
+                "type": "statement",
+                "mainsnak": {
+                    "property": "P170",
+                    "snaktype": "somevalue",
+                    "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
+                },
+                "qualifiers-order": ["P3267", "P2093", "P2699"],
+                "qualifiers": {
+                    "P3267": [
+                        {
+                            "property": "P3267",
+                            "snaktype": "value",
+                            "datavalue": {"type": "string", "value": "84108876@N00"},
+                            "hash": "fa5d6acd35ca6e50077b15e3c224124df6e28595",
+                        }
+                    ],
+                    "P2093": [
+                        {
+                            "property": "P2093",
+                            "snaktype": "value",
+                            "datavalue": {"type": "string", "value": "Jason Pratt"},
+                            "hash": "5208955c9216bddf416e4c58ce5a13ce1ab8d3fb",
+                        }
+                    ],
+                    "P2699": [
+                        {
+                            "property": "P2699",
+                            "snaktype": "value",
+                            "datavalue": {
+                                "type": "string",
+                                "value": "https://www.flickr.com/people/84108876@N00",
+                            },
+                            "hash": "0a168876994e47b9028659a4d67e692138556291",
+                        }
+                    ],
+                },
+                "id": "M34597$10AA104E-CFBD-44C2-8D43-FF8C48FE428A",
+                "rank": "normal",
+            }
+        ]
     }
 
-    existing_sdc: ExistingClaims = {"P170": [existing_statement]}
-    new_sdc: NewClaims = {"claims": [new_statement]}
+    user = flickr_api.get_user(user_id="84108876@N00")
+    new_claims: NewClaims = {"claims": [create_flickr_creator_statement(user)]}
 
-    actions = create_actions(existing_sdc, new_sdc)
-
-    assert actions == [
-        {
-            "property_id": "P170",
-            "action": "do_nothing",
-        }
+    assert create_actions(existing_claims, new_claims, user) == [
+        {"property_id": "P170", "action": "do_nothing"}
     ]
 
 
-def test_it_does_nothing_for_mismatched_creator() -> None:
+def test_it_does_nothing_for_mismatched_creator(flickr_api: FlickrApi) -> None:
     """
     This is a regression test based on the following file:
     https://commons.wikimedia.org/wiki/File:Neasden_Temple_-_Shree_Swaminarayan_Hindu_Mandir_-_Power_Plant.jpg
@@ -492,7 +434,7 @@ def test_it_does_nothing_for_mismatched_creator() -> None:
     The existing P170 statement has a Wikidata entity, which we don't
     know how to handle, so we should do nothing.
     """
-    existing_sdc: ExistingClaims = {
+    existing_claims: ExistingClaims = {
         "P170": [
             {
                 "type": "statement",
@@ -514,51 +456,21 @@ def test_it_does_nothing_for_mismatched_creator() -> None:
             }
         ],
     }
-    new_sdc: NewClaims = {
-        "claims": [
-            {
-                "mainsnak": {"snaktype": "somevalue", "property": "P170"},
-                "qualifiers": {
-                    "P2093": [
-                        {
-                            "datavalue": {"value": "CGP Grey", "type": "string"},
-                            "property": "P2093",
-                            "snaktype": "value",
-                        }
-                    ],
-                    "P2699": [
-                        {
-                            "datavalue": {
-                                "value": "https://www.flickr.com/people/cgpgrey/",
-                                "type": "string",
-                            },
-                            "property": "P2699",
-                            "snaktype": "value",
-                        }
-                    ],
-                    "P3267": [
-                        {
-                            "datavalue": {"value": "52890443@N02", "type": "string"},
-                            "property": "P3267",
-                            "snaktype": "value",
-                        }
-                    ],
-                },
-                "qualifiers-order": ["P3267", "P2093", "P2699"],
-                "type": "statement",
-            }
-        ]
-    }
 
-    assert create_actions(existing_sdc, new_sdc) == [
+    user = flickr_api.get_user(user_id="52890443@N02")
+    new_claims: NewClaims = {"claims": [create_flickr_creator_statement(user)]}
+
+    assert create_actions(existing_claims, new_claims, user) == [
         {"action": "unknown", "property_id": "P170"}
     ]
 
 
-def test_it_ignores_extra_roles_in_creator_if_otherwise_equivalent() -> None:
+def test_it_ignores_extra_roles_in_creator_if_otherwise_equivalent(
+    flickr_api: FlickrApi,
+) -> None:
     # Based on https://commons.wikimedia.org/wiki/File:Programme_(1919)_(14783412743).jpg
     # Retrieved 9 May 2024
-    existing_sdc: ExistingClaims = {
+    existing_claims: ExistingClaims = {
         "P170": [
             {
                 "type": "statement",
@@ -620,50 +532,12 @@ def test_it_ignores_extra_roles_in_creator_if_otherwise_equivalent() -> None:
             }
         ],
     }
-    new_sdc: NewClaims = {
-        "claims": [
-            {
-                "mainsnak": {"snaktype": "somevalue", "property": "P170"},
-                "qualifiers": {
-                    "P2093": [
-                        {
-                            "datavalue": {
-                                "value": "Internet Archive Book Images",
-                                "type": "string",
-                            },
-                            "property": "P2093",
-                            "snaktype": "value",
-                        }
-                    ],
-                    "P2699": [
-                        {
-                            "datavalue": {
-                                "value": "https://www.flickr.com/people/internetarchivebookimages/",
-                                "type": "string",
-                            },
-                            "property": "P2699",
-                            "snaktype": "value",
-                        }
-                    ],
-                    "P3267": [
-                        {
-                            "datavalue": {"value": "126377022@N07", "type": "string"},
-                            "property": "P3267",
-                            "snaktype": "value",
-                        }
-                    ],
-                },
-                "qualifiers-order": ["P3267", "P2093", "P2699"],
-                "type": "statement",
-            },
-        ]
-    }
 
-    assert create_actions(existing_sdc, new_sdc) == [
-        {
-            "property_id": "P170",
-            "action": "do_nothing",
-        }
+    user = flickr_api.get_user(user_id="126377022@N07")
+    new_claims: NewClaims = {"claims": [create_flickr_creator_statement(user)]}
+
+    assert create_actions(existing_claims, new_claims, user) == [
+        {"property_id": "P170", "action": "do_nothing"}
     ]
 
 
@@ -671,76 +545,43 @@ def test_it_ignores_extra_roles_in_creator_if_otherwise_equivalent() -> None:
     "author_name",
     ["flickr user Bryce Edwards", "Flickr user Bryce Edwards", "Bryce Edwards"],
 )
-def test_it_replaces_an_author_name(author_name: str) -> None:
-    existing_claims: ExistingClaims = {
-        "P170": [
-            {
-                "type": "statement",
-                "mainsnak": {
-                    "property": "P170",
-                    "snaktype": "somevalue",
-                    "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
-                },
-                "qualifiers-order": ["P2093"],
-                "qualifiers": {
-                    "P2093": [
-                        {
-                            "property": "P2093",
-                            "snaktype": "value",
-                            "datavalue": {
-                                "type": "string",
-                                "value": author_name,
-                            },
-                            "hash": "a193269ae888171ae46da83b8fb92dbbce2497c7",
-                        }
-                    ]
-                },
-                "id": "M1899107$D9951FC5-A183-43EF-85D6-6E8DFCD6DC34",
-                "rank": "normal",
-            }
-        ],
-    }
-
-    creator_statement: NewStatement = {
-        "mainsnak": {"snaktype": "somevalue", "property": "P170"},
+def test_it_replaces_an_author_name(flickr_api: FlickrApi, author_name: str) -> None:
+    existing_statement: ExistingStatement = {
+        "type": "statement",
+        "mainsnak": {
+            "property": "P170",
+            "snaktype": "somevalue",
+            "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
+        },
+        "qualifiers-order": ["P2093"],
         "qualifiers": {
             "P2093": [
                 {
-                    "datavalue": {"value": "Bryce Edwards", "type": "string"},
                     "property": "P2093",
                     "snaktype": "value",
-                }
-            ],
-            "P2699": [
-                {
                     "datavalue": {
-                        "value": "https://www.flickr.com/people/bryceedwards/",
                         "type": "string",
+                        "value": author_name,
                     },
-                    "property": "P2699",
-                    "snaktype": "value",
+                    "hash": "a193269ae888171ae46da83b8fb92dbbce2497c7",
                 }
-            ],
-            "P3267": [
-                {
-                    "datavalue": {"value": "40286210@N00", "type": "string"},
-                    "property": "P3267",
-                    "snaktype": "value",
-                }
-            ],
+            ]
         },
-        "qualifiers-order": ["P3267", "P2093", "P2699"],
-        "type": "statement",
+        "id": "M1899107$D9951FC5-A183-43EF-85D6-6E8DFCD6DC34",
+        "rank": "normal",
     }
+    existing_claims: ExistingClaims = {"P170": [existing_statement]}
 
-    new_claims: NewClaims = {"claims": [creator_statement]}
+    user = flickr_api.get_user(user_id="40286210@N00")
+    new_statement = create_flickr_creator_statement(user)
+    new_claims: NewClaims = {"claims": [new_statement]}
 
-    assert create_actions(existing_claims, new_claims) == [
+    assert create_actions(existing_claims, new_claims, user) == [
         {
             "property_id": "P170",
             "action": "replace_statement",
-            "statement_id": "M1899107$D9951FC5-A183-43EF-85D6-6E8DFCD6DC34",
-            "statement": creator_statement,
+            "statement_id": existing_statement["id"],
+            "statement": new_statement,
         }
     ]
 
@@ -749,7 +590,9 @@ def test_it_replaces_an_author_name(author_name: str) -> None:
     "author_name",
     ["flickr user Not Bryce Edwards", "fl user Bryce Edwards", "Bruce Edward"],
 )
-def test_it_skips_an_unrecognised_author_name(author_name: str) -> None:
+def test_it_skips_an_unrecognised_author_name(
+    flickr_api: FlickrApi, author_name: str
+) -> None:
     existing_claims: ExistingClaims = {
         "P170": [
             {
@@ -779,41 +622,11 @@ def test_it_skips_an_unrecognised_author_name(author_name: str) -> None:
         ],
     }
 
-    creator_statement: NewStatement = {
-        "mainsnak": {"snaktype": "somevalue", "property": "P170"},
-        "qualifiers": {
-            "P2093": [
-                {
-                    "datavalue": {"value": "Bryce Edwards", "type": "string"},
-                    "property": "P2093",
-                    "snaktype": "value",
-                }
-            ],
-            "P2699": [
-                {
-                    "datavalue": {
-                        "value": "https://www.flickr.com/people/bryceedwards/",
-                        "type": "string",
-                    },
-                    "property": "P2699",
-                    "snaktype": "value",
-                }
-            ],
-            "P3267": [
-                {
-                    "datavalue": {"value": "40286210@N00", "type": "string"},
-                    "property": "P3267",
-                    "snaktype": "value",
-                }
-            ],
-        },
-        "qualifiers-order": ["P3267", "P2093", "P2699"],
-        "type": "statement",
-    }
+    user = flickr_api.get_user(user_id="40286210@N00")
+    new_statement = create_flickr_creator_statement(user)
+    new_claims: NewClaims = {"claims": [new_statement]}
 
-    new_claims: NewClaims = {"claims": [creator_statement]}
-
-    assert create_actions(existing_claims, new_claims) == [
+    assert create_actions(existing_claims, new_claims, user) == [
         {
             "property_id": "P170",
             "action": "unknown",
@@ -822,72 +635,39 @@ def test_it_skips_an_unrecognised_author_name(author_name: str) -> None:
 
 
 def test_it_replaces_an_author_pathalias(flickr_api: FlickrApi) -> None:
+    existing_statement: ExistingStatement = {
+        "type": "statement",
+        "mainsnak": {
+            "property": "P170",
+            "snaktype": "somevalue",
+            "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
+        },
+        "qualifiers-order": ["P2093"],
+        "qualifiers": {
+            "P2093": [
+                {
+                    "property": "P2093",
+                    "snaktype": "value",
+                    "datavalue": {"type": "string", "value": "dwhartwig"},
+                    "hash": "a0c63c1fe81dff8f300427326a19939afb65ad95",
+                }
+            ]
+        },
+        "id": "M108119123$1B7C1641-4F9A-4B73-B059-190083E2AC9F",
+        "rank": "normal",
+    }
+
+    existing_claims: ExistingClaims = {"P170": [existing_statement]}
+
     user = flickr_api.get_user(user_id="9751269@N07")
+    new_statement = create_flickr_creator_statement(user)
+    new_claims: NewClaims = {"claims": [new_statement]}
 
-    existing_claims: ExistingClaims = {
-        "P170": [
-            {
-                "type": "statement",
-                "mainsnak": {
-                    "property": "P170",
-                    "snaktype": "somevalue",
-                    "hash": "d3550e860f988c6675fff913440993f58f5c40c5",
-                },
-                "qualifiers-order": ["P2093"],
-                "qualifiers": {
-                    "P2093": [
-                        {
-                            "property": "P2093",
-                            "snaktype": "value",
-                            "datavalue": {"type": "string", "value": "dwhartwig"},
-                            "hash": "a0c63c1fe81dff8f300427326a19939afb65ad95",
-                        }
-                    ]
-                },
-                "id": "M108119123$1B7C1641-4F9A-4B73-B059-190083E2AC9F",
-                "rank": "normal",
-            }
-        ],
-    }
-    new_claims: NewClaims = {
-        "claims": [
-            {
-                "mainsnak": {"snaktype": "somevalue", "property": "P170"},
-                "qualifiers": {
-                    "P2093": [
-                        {
-                            "datavalue": {"value": "Daniel Hartwig", "type": "string"},
-                            "property": "P2093",
-                            "snaktype": "value",
-                        }
-                    ],
-                    "P2699": [
-                        {
-                            "datavalue": {
-                                "value": "https://www.flickr.com/people/dwhartwig/",
-                                "type": "string",
-                            },
-                            "property": "P2699",
-                            "snaktype": "value",
-                        }
-                    ],
-                    "P3267": [
-                        {
-                            "datavalue": {"value": "9751269@N07", "type": "string"},
-                            "property": "P3267",
-                            "snaktype": "value",
-                        }
-                    ],
-                },
-                "qualifiers-order": ["P3267", "P2093", "P2699"],
-                "type": "statement",
-            },
-        ]
-    }
-
-    assert create_actions(existing_claims, new_claims, user) != [
+    assert create_actions(existing_claims, new_claims, user) == [
         {
             "property_id": "P170",
-            "action": "unknown",
+            "action": "replace_statement",
+            "statement_id": existing_statement["id"],
+            "statement": new_statement,
         }
     ]

--- a/tests/fixtures/cassettes/test_a_null_creator_statement_is_replaced.yml
+++ b/tests/fixtures/cassettes/test_a_null_creator_statement_is_replaced.yml
@@ -1,0 +1,64 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=44124472424%40N01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VSy27DIBA8J1+BuCdgy0mTyHZ67aWXfoBFzTpGwYAAN/38LnGatFEfEkjM7szs
+        Ltpy/z5o8gY+KGsqmi05JWBaK5U5VHSM3WJDyb6elz44EqKIFbVHitihxBqiZEWLIsuL4iEv8uLx
+        mWeUmPBjWAXnbUWxggqNBA0RUJ1ga00Aj11UdMVX2ynSCT9UdE2JE7FvhFYiVDREL8wBlIng9SiB
+        kl6EJjWGSbRKSMjOA1xhAolhpPCyCb1y7jzchX1OgxxbEfELhG48BDv6Fs6G9XxWjtibEQPUL1Px
+        p8/iJbumkCYhtF655EJY0rneRhtGr+s+Rhd2jJ1Op2WnVXv0y9YObCKw+5lYeckkafLxtlMa/jIC
+        6zT8aHTTotNgX/8x+rWjm/Q6GfY2KzvlQ5QiQhRHMHXOeb7gGR7C+S6dbcnuON9kdca3nG/wfiWe
+        rVs7mljn603JpidWvvwMLiCbNjC9cDfr+QctVTzHygIAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:52:54 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 b67f2634ca600af6b67517b65a411b56.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - oPJ5JBYp_BU0JdkQaFJGs84s32Z0EbPwrqyLAMPse98ywilQ41Ua1w==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:52:54 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66506376-5c0dba822c6510401811b5d6;Root=1-66506376-1738aae868e7aebd4799dfda
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.41.36
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_does_nothing_for_mismatched_creator.yml
+++ b/tests/fixtures/cassettes/test_it_does_nothing_for_mismatched_creator.yml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=52890443%40N02
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VTwW7bMAw9N18h6LomUtw0dQPbHbAVOawddljPhmLRsRBZEiR52fb1o+IkXVNg
+        u4mP7z2SIlg8/Ow1+QE+KGtKOp9xSsA0ViqzLekQ22lOyUM1KXxwJEQRS2p3FGOHEmuIkiW9zfJ7
+        vljcfPzKM0pMeI+p4LwtKXqrUEvQEAF1KWysCeCxfkkX82w+Iq3wPdpS4kTsaqGVCCVttm7r4Rcl
+        nQh16gQxdEiRkK0HOIcpSAwjhZd16JRzh2mO7EMa5NCIiDMLXXsIdvANHAyryVUxYEtG9FB9Wn8j
+        ayxasDOEaQ9CX6TPEKa1HZ2rJ2ukNdfkxSicl3zBJqTtC3YmIDmqHn5bA0SLDeiSrp+/r8jnYaMV
+        Ch9xC5vBb7tr8qTCJnmNnpTYtg2Ay/jA+YrjYCefOn3+4+CtA3binnIlze4oYWlCCaHxyqU2R8B1
+        NtoweF11MbqwYmy/389arZqdnzW2ZyOBHbfAiiOQFEnubas0/EsP1mn4W/8qQYPebv6jv6z/qji3
+        j51cFa3yIUoRIYodmCrjfDHl+ZQvCL9d3dyvsqxgF5w3smqe5fNlfpe/IR6sGzuYWGXL5bJg4xtL
+        Hz8CT4KNN5FeeC3V5A+ebaibXAMAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:48:37 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 c563be5783a6881ba547ef83aba03e9e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Y3ty2Ftc9yQxoQOd_CelvLvXETX4pAq434GtUokkRUvWyzwxBXG9Qw==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:48:36 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:48:36 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66506274-25f1342901a985b53fa7e4a6;Root=1-66506274-6cbf903c1224487707b48808
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.10.17
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_does_nothing_if_creator_differs_only_in_url.yml
+++ b/tests/fixtures/cassettes/test_it_does_nothing_if_creator_differs_only_in_url.yml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=84108876%40N00
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VTTY/TMBA9b3+F5QMCiTYJ7S7ZJcmCoBcOqNKWczSNJ42pY1u2Q1f8esZJaWEX
+        gZRD5s17b77k4v6xV+w7Oi+NLnm2SDlD3Rgh9b7kQ2jnOWf31axw3jIfIJTcHDjFliRGMylKnq+y
+        NM/f3rz/kpJa++eY9NYZcudM+lqgwoCkI7JsjPboqP6UpbAF14+BhdDVoCT4kn8DKmYdhMBZB76O
+        nRBMDmRc70DsseQEagFO0ASPVjpCKB/ZIFqHlzAG0WEk176T1o7TnthjGsXQQKCdgKodejO4BseC
+        1eyqGKhlDT1Wn2NbbBP7KpIzSgyHoJ4zzigxlJn8q40Mwe8Gt+9es82HIjkniBRkjz+MRqZgh6rk
+        a/CBSrMt4ezl1wf2Anr7jn0EDQJecWba1iOdaJ5e38Vb/NLX8STrh+31+tP2gtKWV5wlcSKBvnHS
+        xoYmwHYmGD84VXUhWH+XJMfjcdEq2RzcojF9MhGSy2GS4oRFUXRwppUK/2WBxip8YnFRkUdvdv+x
+        +EsXF9F5Durnqmil80FAwAAH1FV2m9/SnuZpxtKUtkVfkTzh/CGrsixdrpbLPH3zG3G0bsygQ5Xd
+        5Msimf6p9Gkd9FaS6bHEP3pG1ewn63v8Q3UDAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:49:40 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 1dc8492dd1b0b02885c719ffa2b4ec54.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - NAjZ4oVZq8228ZEhqm4jOG57LmptPfBYAeZUgT2PFYrRm0sK8xlmDQ==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:49:40 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:49:40 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-665062b4-057c3f2a55e5321e2ab81ec7;Root=1-665062b4-61abafd75c3c63b2473ff80b
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.41.36
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_ignores_extra_roles_in_creator_if_otherwise_equivalent.yml
+++ b/tests/fixtures/cassettes/test_it_ignores_extra_roles_in_creator_if_otherwise_equivalent.yml
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=126377022%40N07
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VUwW7bMAw9N19B+FC0QBo7dpIGre1uuxUYdto9kGXaFiKLniQ33d+PitOmK7YW
+        8EGi3nt8JGXlD8+9hie0TpEpouUiiQCNpFqZtohG39xsI3goZ7l1AzgvfBHRPuL9wBQyoGompZvs
+        9jZJ0y8/ktsIjPtHULnBEkMjUG5Xo0aPzORkSpJxaNlBEWXbdTpFGmH7IlpFMAjf7YRWwhWRMh6t
+        QS+s7NQTVkR71YsWXQSdcLvgjlGsyal2lahbLCIOmlrYmqt6HpTlSJqk681mkyQMDDRRNxY5ftqG
+        TZA6snauU8NwbMXbY6xHKTw3TOidRUejlXjMXM4u8pGrMaLH8vFkF75OfuEbG4bHo+M8foUxpUYn
+        rRqCYvmzQ3jPnIOAdbK8ktdX2TUYMjdcYaP8nJsJ1ah0mBZjatUqLzRoVVlhfwM1ZymnPDrgsoB8
+        hxbkqP1oGSysV42Q3oEyrwoN2X4B39UeWXYQPOwX0TkcMDT4SdUIoVkgJFfvwBNwLzAMh6/GHDrl
+        PFklDK+d7EiLEOXczOZJcionKo01F8emQrxFg8HRMFZaycVsdqn9vYDOYlNc/hrJ33feD+4ujk83
+        YEG2jacTzq1PIENMQGvZs6GGtKbDhLlsWW6axcRk+ViEaB6/HQFPZOjIkxutLl9SHg6HRcO29nYh
+        qY8nQPzfKxnnJ0jQCIJhYBo/UkQaNH6seBZhyZ6qTxQ/93jWeC2a3V7kjbLO18Lzz7ZHUy636fom
+        WfIHSXJ3/PL4HeYvWrlcJZssW6Xr7A3wKC1pNL5cZ+l2tdzk8bTl7Kd+8dMST29LWPGrU87+APtJ
+        HJOkBAAA
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:47:23 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 1dc8492dd1b0b02885c719ffa2b4ec54.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - I43l7QgurqD2RPaDIZNKqZryg15Qf2gudLhYCBgMjlRYl7iVBIGDUg==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:47:23 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:47:23 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6650622b-62c0d1a345593b362faf4c56;Root=1-6650622b-0ea400da4c1f2dac19c2cbee
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.32.246
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_replaces_an_author_name[Bryce Edwards].yml
+++ b/tests/fixtures/cassettes/test_it_replaces_an_author_name[Bryce Edwards].yml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=40286210%40N00
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VUwW7bMAw9N19B6NDLmsh22rRIbXcbtsMO7QoMw4BdAkWmYyGy5EnysvbrR9lp
+        2q3BdhPJ9x4faVn5za9Ww090XllTsHSWMEAjbaXMpmB9qKdXDG7KSe58Bz6IUDC7ZRR3RLEGVFWw
+        8yS7WmRp8vYuIbbxr3PKd84WjKrKryrUGJB4MZTWeHTUv2DzizGuhWvJCYNOhGYltBK+YGv3IBGr
+        nXCVZ9AIv4pmqEAiMRJV7RAPYQwiwlREWPlGdd0w0B49lLHqpQg0ttArh972TuIgWE5O8p5cGdFi
+        +T42ho9j55wf8oRxKPQxzCFPGG3HHuWH3iAt9QzucAffiUnecn4oEzSoFh+tQdBijbpg73q5jagz
+        +IZak/1gDQNb1x7pK7xJs2Vc9xNrFbd+L6SqleRP1OdywS7nDHgcrUIvneoGV59AtCBAowy9Qwci
+        wOcgNha+GjVcivBwBseswxQCCtmQLVAG7q1WQUmh4UvoK4V+Mrl9gO6QXWtLOE/6SzjV4VpA47Au
+        Tn/0Nlw3IXRLzne73UyrNbphYTPrNjPzOCLA0ULGo7FERBfNGltbre1uLJxuwvVxCerHRSzn/OXs
+        tIquscH63ukyevB7E7VWcutm0rZ8BPCXt4/n+2ykRQ1na6XxXyJoO42vRJ55pNLa9X9Ejjp5ph2m
+        IU8nea2cD5UIGMQWTZklSTpNLqbJApL5Mlsskyznf2H+oJVpOs8W9FMvzl8AB2lpexPKNLu8WuR8
+        DKj3fif0MPDxZYgnejPKyW9N+szpYgQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:46:31 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 e8f9b46f64c4f609a553f92a0c9eae18.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - elovBptu3MjQCJdBmWianwh8JwjOiowGnidHrsV3Jq8ogvnaK0qHnw==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:46:30 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:46:30 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-665061f6-2f848ba2357e664c32c9ae70;Root=1-665061f6-6e07ad251647aedf0858eb8e
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_replaces_an_author_name[flickr user Bryce Edwards].yml
+++ b/tests/fixtures/cassettes/test_it_replaces_an_author_name[flickr user Bryce Edwards].yml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=40286210%40N00
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VUwW7bMAw9N19B6NDLmsh22rRIbXcbtsMO7QoMw4BdAkWmYyGy5EnysvbrR9lp
+        2q3BdhPJ9x4faVn5za9Ww090XllTsHSWMEAjbaXMpmB9qKdXDG7KSe58Bz6IUDC7ZRR3RLEGVFWw
+        8yS7WmRp8vYuIbbxr3PKd84WjKrKryrUGJB4MZTWeHTUv2DzizGuhWvJCYNOhGYltBK+YGv3IBGr
+        nXCVZ9AIv4pmqEAiMRJV7RAPYQwiwlREWPlGdd0w0B49lLHqpQg0ttArh972TuIgWE5O8p5cGdFi
+        +T42ho9j55wf8oRxKPQxzCFPGG3HHuWH3iAt9QzucAffiUnecn4oEzSoFh+tQdBijbpg73q5jagz
+        +IZak/1gDQNb1x7pK7xJs2Vc9xNrFbd+L6SqleRP1OdywS7nDHgcrUIvneoGV59AtCBAowy9Qwci
+        wOcgNha+GjVcivBwBseswxQCCtmQLVAG7q1WQUmh4UvoK4V+Mrl9gO6QXWtLOE/6SzjV4VpA47Au
+        Tn/0Nlw3IXRLzne73UyrNbphYTPrNjPzOCLA0ULGo7FERBfNGltbre1uLJxuwvVxCerHRSzn/OXs
+        tIquscH63ukyevB7E7VWcutm0rZ8BPCXt4/n+2ykRQ1na6XxXyJoO42vRJ55pNLa9X9Ejjp5ph2m
+        IU8nea2cD5UIGMQWTZklSTpNLqbJApL5Mlsskyznf2H+oJVpOs8W9FMvzl8AB2lpexPKNLu8WuR8
+        DKj3fif0MPDxZYgnejPKyW9N+szpYgQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:46:30 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 0e5b8ac0c35b795a035fafc85d9c0c7c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - MgrCViPKhjiIQVY63sOa7wuid9ym29UqBUhAxnbgr8Ujroe1iq_Kcg==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:46:30 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:46:30 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Root=1-665061f6-140150771d77e1e8004a140e
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.41.36
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_replaces_an_author_pathalias.yml
+++ b/tests/fixtures/cassettes/test_it_replaces_an_author_pathalias.yml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=9751269%40N07
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VTwW7bMAw9N18h6DBswBLZaZ04qe0OWA87FQGSng3FomMtsiRI8lLs60fbnbOu
+        wHYTHx8fH0koe3hpFfkBzkujcxovIkpAV0ZIfcppF+p5SslDMcuct8QHHnJqzhRjiyVGEylyulkn
+        8XK1+fIUrSnR/h0kvXUGtSmRvhSgIABWYSNZGe3BYfecrpLkNhmhmrsWgRUlloem5Epyn1NxabgL
+        F3mipOG+7L0giiooXh65OEFOEdSCO4EzvFjpEMF8z+aidnAN+6BXGMilb6S1w7yv7CENoqt4wK1w
+        VTrwpnMVDA2L2U3WoW3NWygmVxmbMMw74GrIP3ItQZFvo/WMTQkkKTM2KPbBdKcmGP2ZPGuJ2yF7
+        nA58xiYK0oNs4afRQBQ/gsrpjleylhU5IE4+Pu/JB97ae/KVay74p3vEv3f4psTUtQc83DxKtxGO
+        +Fuo7C+12x/S3ePhiuYUz8D6IQX4yknbWxwB25hgfOdU0YRg/Zaxy+WyqJWszm5RmZaNBDYthWWv
+        UF/TCzhTSwX/UgBjFbxVuBahRGuO/1F47+FaMw2Bbm6yWjofBG468DPoIt6sNvMomccpiaLt7d12
+        uczYX5w3ZUUcJZs4Xt+lyR/EQboynQ7FOo1WUcbGAHu/bgO/Dxv/T//Cn1XMfgG4Q0DHiAMAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:36:47 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 8939c5b3fb6161054bb337f7b9dd7fc4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - wWhZ5VoJJWOD4UXgiHjI4_QlXbtpTwIC1eOPZ6Fj_5apmLUPRXuKtw==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:36:47 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:36:47 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66505fab-79ff0d272dc2ccc74be594f2;Root=1-66505fab-2e62ce834aa6043b57508993
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.31.120
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_skips_an_unrecognised_author_name[Bruce Edward].yml
+++ b/tests/fixtures/cassettes/test_it_skips_an_unrecognised_author_name[Bruce Edward].yml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=40286210%40N00
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VUwW7bMAw9N19B6NDLmsh22rRIbXcbtsMO7QoMw4BdAkWmYyGy5EnysvbrR9lp
+        2q3BdhPJ9x4faVn5za9Ww090XllTsHSWMEAjbaXMpmB9qKdXDG7KSe58Bz6IUDC7ZRR3RLEGVFWw
+        8yS7WmRp8vYuIbbxr3PKd84WjKrKryrUGJB4MZTWeHTUv2DzizGuhWvJCYNOhGYltBK+YGv3IBGr
+        nXCVZ9AIv4pmqEAiMRJV7RAPYQwiwlREWPlGdd0w0B49lLHqpQg0ttArh972TuIgWE5O8p5cGdFi
+        +T42ho9j55wf8oRxKPQxzCFPGG3HHuWH3iAt9QzucAffiUnecn4oEzSoFh+tQdBijbpg73q5jagz
+        +IZak/1gDQNb1x7pK7xJs2Vc9xNrFbd+L6SqleRP1OdywS7nDHgcrUIvneoGV59AtCBAowy9Qwci
+        wOcgNha+GjVcivBwBseswxQCCtmQLVAG7q1WQUmh4UvoK4V+Mrl9gO6QXWtLOE/6SzjV4VpA47Au
+        Tn/0Nlw3IXRLzne73UyrNbphYTPrNjPzOCLA0ULGo7FERBfNGltbre1uLJxuwvVxCerHRSzn/OXs
+        tIquscH63ukyevB7E7VWcutm0rZ8BPCXt4/n+2ykRQ1na6XxXyJoO42vRJ55pNLa9X9Ejjp5ph2m
+        IU8nea2cD5UIGMQWTZklSTpNLqbJApL5Mlsskyznf2H+oJVpOs8W9FMvzl8AB2lpexPKNLu8WuR8
+        DKj3fif0MPDxZYgnejPKyW9N+szpYgQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:42:37 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 55f3922719298ab498eeea0c325b9d12.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - h9mErt-iBwdvxI55FiJv-iNBMITJSEATzzLJ1seCdJLLUAfsZoXhUg==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:42:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:42:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6650610d-60d98bcf6ea8510a22457e14;Root=1-6650610d-1e8fe89e79cdd9aa61de9506
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_skips_an_unrecognised_author_name[fl user Bryce Edwards].yml
+++ b/tests/fixtures/cassettes/test_it_skips_an_unrecognised_author_name[fl user Bryce Edwards].yml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=40286210%40N00
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VUwW7bMAw9N19B6NDLmsh22rRIbXcbtsMO7QoMw4BdAkWmYyGy5EnysvbrR9lp
+        2q3BdhPJ9x4faVn5za9Ww090XllTsHSWMEAjbaXMpmB9qKdXDG7KSe58Bz6IUDC7ZRR3RLEGVFWw
+        8yS7WmRp8vYuIbbxr3PKd84WjKrKryrUGJB4MZTWeHTUv2DzizGuhWvJCYNOhGYltBK+YGv3IBGr
+        nXCVZ9AIv4pmqEAiMRJV7RAPYQwiwlREWPlGdd0w0B49lLHqpQg0ttArh972TuIgWE5O8p5cGdFi
+        +T42ho9j55wf8oRxKPQxzCFPGG3HHuWH3iAt9QzucAffiUnecn4oEzSoFh+tQdBijbpg73q5jagz
+        +IZak/1gDQNb1x7pK7xJs2Vc9xNrFbd+L6SqleRP1OdywS7nDHgcrUIvneoGV59AtCBAowy9Qwci
+        wOcgNha+GjVcivBwBseswxQCCtmQLVAG7q1WQUmh4UvoK4V+Mrl9gO6QXWtLOE/6SzjV4VpA47Au
+        Tn/0Nlw3IXRLzne73UyrNbphYTPrNjPzOCLA0ULGo7FERBfNGltbre1uLJxuwvVxCerHRSzn/OXs
+        tIquscH63ukyevB7E7VWcutm0rZ8BPCXt4/n+2ykRQ1na6XxXyJoO42vRJ55pNLa9X9Ejjp5ph2m
+        IU8nea2cD5UIGMQWTZklSTpNLqbJApL5Mlsskyznf2H+oJVpOs8W9FMvzl8AB2lpexPKNLu8WuR8
+        DKj3fif0MPDxZYgnejPKyW9N+szpYgQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:42:37 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 6e99bccc56a80044a47d241008098118.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - fuoDE60WNvAj8J7TAL0LRaUlBnUoq6y71Bsw_zHwG2mz_5HhEUSxIw==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:42:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:42:37 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6650610d-1019c68d081ae36e3d67ed3f;Root=1-6650610d-5820b2af1eecb5b41d8a62f8
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.41.36
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_it_skips_an_unrecognised_author_name[flickr user Not Bryce Edwards].yml
+++ b/tests/fixtures/cassettes/test_it_skips_an_unrecognised_author_name[flickr user Not Bryce Edwards].yml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.people.getInfo&user_id=40286210%40N00
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4VUwW7bMAw9N19B6NDLmsh22rRIbXcbtsMO7QoMw4BdAkWmYyGy5EnysvbrR9lp
+        2q3BdhPJ9x4faVn5za9Ww090XllTsHSWMEAjbaXMpmB9qKdXDG7KSe58Bz6IUDC7ZRR3RLEGVFWw
+        8yS7WmRp8vYuIbbxr3PKd84WjKrKryrUGJB4MZTWeHTUv2DzizGuhWvJCYNOhGYltBK+YGv3IBGr
+        nXCVZ9AIv4pmqEAiMRJV7RAPYQwiwlREWPlGdd0w0B49lLHqpQg0ttArh972TuIgWE5O8p5cGdFi
+        +T42ho9j55wf8oRxKPQxzCFPGG3HHuWH3iAt9QzucAffiUnecn4oEzSoFh+tQdBijbpg73q5jagz
+        +IZak/1gDQNb1x7pK7xJs2Vc9xNrFbd+L6SqleRP1OdywS7nDHgcrUIvneoGV59AtCBAowy9Qwci
+        wOcgNha+GjVcivBwBseswxQCCtmQLVAG7q1WQUmh4UvoK4V+Mrl9gO6QXWtLOE/6SzjV4VpA47Au
+        Tn/0Nlw3IXRLzne73UyrNbphYTPrNjPzOCLA0ULGo7FERBfNGltbre1uLJxuwvVxCerHRSzn/OXs
+        tIquscH63ukyevB7E7VWcutm0rZ8BPCXt4/n+2ykRQ1na6XxXyJoO42vRJ55pNLa9X9Ejjp5ph2m
+        IU8nea2cD5UIGMQWTZklSTpNLqbJApL5Mlsskyznf2H+oJVpOs8W9FMvzl8AB2lpexPKNLu8WuR8
+        DKj3fif0MPDxZYgnejPKyW9N+szpYgQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Fri, 24 May 2024 09:42:36 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 1c3d157dbb0eab09a086f8c752d93b44.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - YXx_8-deFn6qSj3vW5SGrLebuofIiFEsvSxMIZ-0QOiS061zcB5kuw==
+      X-Amz-Cf-Pop:
+      - MAN51-P3
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:42:36 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sun, 23-Jun-2024 09:42:36 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6650610c-08b3f73309862bbd274ab455;Root=1-6650610c-4918252b4e48be863335c656
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.16.171
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
For example in https://commons.wikimedia.org/wiki/File:Mesa_Verde_-_51198350702.jpg, there's a photo from <code>https​://www.flickr.com/photos/<strong>dhartwig</strong>/51198350702/</code> with the following Creator statement:

<img width="635" alt="Screenshot 2024-05-24 at 10 57 05" src="https://github.com/Flickr-Foundation/flickypedia/assets/301220/a60c7710-5175-4533-9642-05ccb8f585f5">

I can see how the tool got there, but this isn't very useful – it's not the unambiguous Flickr user ID, and it's not the username (although I've made that mistake before!).

If we can see the pathalias is the only entry in the author name string, we can replace this statement with a richer creator statement.