### PR TITLE
Add an SDC statement for BHL Page ID iff (1) the photo comes from the BHL account and (2) the photo has a `bhl:pageid` machine tag

### DIFF
--- a/src/flickypedia/structured_data/claims.py
+++ b/src/flickypedia/structured_data/claims.py
@@ -3,7 +3,9 @@ import typing
 
 from flickr_photos_api import SinglePhoto
 
+from .flickr_users import FlickrUsers
 from .statements import (
+    create_bhl_page_id_statement,
     create_copyright_status_statement,
     create_date_taken_statement,
     create_flickr_creator_statement,
@@ -94,6 +96,15 @@ def _create_sdc_claims_for_flickr_photo(
     )
 
     statements.append(published_in_statement)
+
+    # Add the BHL Photo ID statement, but only if this is the BHL user.
+    if photo["owner"]["id"] == FlickrUsers.BioDivLibrary:
+        bhl_page_id_statement = create_bhl_page_id_statement(
+            photo_id=photo["id"], tags=photo["tags"]
+        )
+
+        if bhl_page_id_statement is not None:
+            statements.append(bhl_page_id_statement)
 
     return {"claims": statements}
 

--- a/src/flickypedia/structured_data/flickr_users.py
+++ b/src/flickypedia/structured_data/flickr_users.py
@@ -1,0 +1,7 @@
+class FlickrUsers:
+    """
+    Named constants for the NSID of certain Flickr users.
+    """
+
+    # https://www.flickr.com/photos/biodivlibrary/
+    BioDivLibrary = "61021753@N02"

--- a/src/flickypedia/structured_data/statements/__init__.py
+++ b/src/flickypedia/structured_data/statements/__init__.py
@@ -1,3 +1,4 @@
+from .bhl_page_id_statement import create_bhl_page_id_statement
 from .copyright_status_statement import create_copyright_status_statement
 from .creator_statement import create_flickr_creator_statement
 from .date_taken_statement import create_date_taken_statement
@@ -8,6 +9,7 @@ from .source_statement import create_source_statement
 from .published_in_statement import create_published_in_statement
 
 __all__ = [
+    "create_bhl_page_id_statement",
     "create_copyright_status_statement",
     "create_date_taken_statement",
     "create_flickr_creator_statement",

--- a/src/flickypedia/structured_data/statements/bhl_page_id_statement.py
+++ b/src/flickypedia/structured_data/statements/bhl_page_id_statement.py
@@ -1,0 +1,39 @@
+import re
+
+
+def guess_bhl_page_id(*, photo_id: str, tags: list[str]) -> str | None:
+    """
+    Given the metadata from the original Flickr photo, work out what
+    the BHL Page ID for this photo is (if any).
+
+    == How it works ==
+
+    We look for a machine tag with the `bhl:page` namespace.
+
+    BHL photos usually include a link to the page, but we can't trust
+    it to point to the original photo.  Sometimes these are ambiguous --
+    we don't trust these links, so we don't look at them.
+    """
+    candidate_page_ids = set()
+
+    # Most BHL photos have a machine tag of the form:
+    #
+    #     bhl:page=33665643
+    #
+    # Look for any tags which match this pattern.
+    for t in tags:
+        m = re.match(r"^bhl:page=(?P<page_id>[0-9]+)$", t)
+
+        if m is not None:
+            candidate_page_ids.add(m.group("page_id"))
+
+    # In general we expect that this should be an unambiguous list --
+    # however, we double check to be sure!
+    if not candidate_page_ids:
+        print(f"Warning: no BHL page ID on {photo_id}")
+        return None
+    elif len(candidate_page_ids) == 1:
+        return candidate_page_ids.pop()
+    else:
+        print(f"Warning: ambiguous BHL page ID on {photo_id} ({candidate_page_ids})")
+        return None

--- a/src/flickypedia/structured_data/statements/bhl_page_id_statement.py
+++ b/src/flickypedia/structured_data/statements/bhl_page_id_statement.py
@@ -1,4 +1,14 @@
+"""
+Create a statement for BHL Page ID.
+
+Here BHL = Biodiversity Heritage Library
+https://www.flickr.com/photos/biodivlibrary/
+"""
+
 import re
+
+from ..types import NewStatement, to_wikidata_string_value
+from ..wikidata_properties import WikidataProperties
 
 
 def guess_bhl_page_id(*, photo_id: str, tags: list[str]) -> str | None:
@@ -36,4 +46,25 @@ def guess_bhl_page_id(*, photo_id: str, tags: list[str]) -> str | None:
         return candidate_page_ids.pop()
     else:
         print(f"Warning: ambiguous BHL page ID on {photo_id} ({candidate_page_ids})")
+        return None
+
+
+def create_bhl_page_id_statement(
+    *, photo_id: str, tags: list[str]
+) -> NewStatement | None:
+    """
+    Creates a BHL Photo ID statement for a Flickr photo.
+    """
+    bhl_page_id = guess_bhl_page_id(photo_id=photo_id, tags=tags)
+
+    if bhl_page_id is not None:
+        return {
+            "mainsnak": {
+                "datavalue": to_wikidata_string_value(value=bhl_page_id),
+                "property": WikidataProperties.BhlPageId,
+                "snaktype": "value",
+            },
+            "type": "statement",
+        }
+    else:
         return None

--- a/src/flickypedia/structured_data/wikidata_properties.py
+++ b/src/flickypedia/structured_data/wikidata_properties.py
@@ -16,6 +16,7 @@ class WikidataProperties:
     DescribedAtUrl = "P973"
     DeterminationMethod = "P459"
     AuthorName = "P2093"
+    BhlPageId = "P687"
     CoordinatesOfThePointOfView = "P1259"
     FlickrPhotoId = "P12120"
     FlickrUserId = "P3267"

--- a/tests/fixtures/cassettes/TestClaims.test_includes_statement_if_bhl_user.yml
+++ b/tests/fixtures/cassettes/TestClaims.test_includes_statement_if_bhl_user.yml
@@ -1,0 +1,212 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=7982377911
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA81XTXPbNhA9x78Cw8z4ZImkSIqkLTkfTZPMNEkzk7SZnjwQCYmoQYIFQCnKrbf8
+        OP+oPoCS5VhOq+jU8dgGsFjs213g7XLy5HMtyJIpzWUz9cJh4BHWFLLkzWLqdWY+yDzy5PJkonRL
+        tKFm6slrD/O2kkYSXk69NM9GUZrmYegRzQrFsCdlcV7mlIWJXVM4f+plYYqz5lTVUy/3SEkN61oh
+        aclwSBjFaRLl2RhbuJ7TpVTcsKkHOIIXrNEYh5hoOmdmfSXYkgknVRKgHHZMoLTgDRVbGEE8YuN8
+        ljDY28rmUtXWjT/bhUeWnK004IxygK9ZyenUc57BxUcTuWqYIo22Xo7DYBQC4tN3wcgjHZxqaA1Q
+        z7l8wZdv+ExRtQYcRsWtoOQusGZNXjO4QxeM3G4UstjghsOFhIN9lJLYhQArfaTGHmmpqa6o4BRI
+        ZxypWYqNOYB8NFnwuSH2zxUTcH8mbKg80rDV1VzIlZ3YfY8mW/FV2SlnWxP/WMnEtxZtkHwXJTsy
+        3Ah22WTR1SoMk2Di9wuQlEwXirfW5uV7JedD8kINycdK1uzm79PHQZRfaPJSSEXJUjbkBeuMLipB
+        m/KM/HrzVRumFONFRbqmJCVy8qGoVox/OSO8IZ+kMk7wnAvsn3c3X92GTjC3/Jp2mlyQmhsyHMIq
+        bpBo3NDa+kQFTidvoSUEU8PhySum6OC3Bqt1ZVXPXw5/HpJf5M3XChvOwiwbD8I8irH1VJgLSirF
+        5tPTvzppLipj2nPf77PU536Tq6FUC7/FFfDjaBTip1fAhREb3UbiHOsorpycS4Hc9XtOF+bioBOB
+        xqd298nJO0aVWBMqBHm84g0jrZJlV7CSLIScYXlNCkRfk7mSNSk6YfiSKk3knPzODdd4GQ0HGjok
+        HxgjiB0i/XhWwRvyf/WanNK6vbC/5CmT4rs4IbvNhvYTsFcQ+xLpsmzwY2n596Nu8zHx774APIgl
+        13zGhaUGrttuBo5zjxbUpzhrwDdgM8uDNRdrN7EvdWI5U5NW4kHc40xDrxk4cBSEo0GQD8KIBNl5
+        lJ7HIBMnWyjadIKChvrz3GLXXDd4vj3NUm261loAkiQPxsE4DuONYTCjoRvABUV9qGvWgEShhykt
+        y5oZUOcWZ+/R95Tg510lTJ1znbYECUkJSLYuuIhgPhMStag31Sq+s6srqnqycwdsUOlLUM/tGOuN
+        tFFzW1omW9BCRXU/2kEGO2tHpxi4sgbCD8I4SAa7+jYYBRniSTtTSVD1tyWhX324KFCw8LNOG8Up
+        ygwtKrzIKxiy5i/BMVYAuqSL/0YQBVGWpQjGcSh+UuvWyAXu1QNIip3wMDRhNBrFwdEhcYyv9yOC
+        soX1AyHEaXpsMMD0NW1Qte+nZNELDkMQxegujsvGe5Q480AAWrd+mPlRaPui4+x/WHHzhSlbaPeD
+        oHfCw5BkcZLk4zw6Fs1bpsyXbYd0hvaAkXdsRf6Q6po8R5vX8IIK8oqqkjX7cGurvSm2pmJof9ZQ
+        nG31Fk7tMEfydJxmyfH3GmXy3Jb66abU3wOLfuz+jh/BdXy6y+KcIwiGzzlazR/oVfYd2D/qgQ4F
+        LY8NwyYKh/k4yqMwT5Ojn5Shn2Uj6/X5jOMfp2L6bT+z78q+xtJ2QNsG6EDY2Ti+e/HHWZQG+Qhf
+        C7ePsy8NPz1zjS7Xhhd4+cqWBiCkBaNs/1IDiZMcBiIL0jhLUA6PY4OPePC2F36P/mIfiumltvk4
+        DE2SZOM8Hd2pDmGGD6hx5MJyG6w+LE/761MxtYvJnS6UvBk+GJxdmsQWlPtvS/mkU6Iv6RgQs25h
+        xn3b2TvpXdrrr9Grr1ar4RzdyrUaomnw3Q696eA3dOLvWgB/4uM0993THz/pNewAn8iXJ/8A3Gfx
+        MlEPAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:26:19 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 da0472696f37c3fd9136c0c43a0dc866.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Va44A0relHuVu4D_zT9Tz09pnUYf2Gor4FXUTmKtFgaMBtfEz8Jj9A==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:26:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:26:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6679820b-31bdb4dd31f6161e6c6d3c6a;Root=1-6679820b-33ab11fa6b870aff05ca2f53
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.34.3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WUS0/DMBCEz/RXrHyCQ+KWN6gpQq3EBRACIc6usyRWEruynRT49WwfKbRKKGpv
+        yWH8zUoz07/5KHKo0DpldMR6YZcBamlipZOIlf49uGRwM+j0rZuA88JHzGSM/nMlUTt0g85B/Q0q
+        jhjptSgwYrd5Ds8qSb2DZ3RoK4wZlDaPGAO+qTpdqby3alx6cgP3C8RSlXo/cdecS4vCqwqlKQqj
+        XWhswmszfPzJj8MubyCcNxCCRzNCqyq3GyrQcRvtpJmmh2QarVQi35st/8Afb8XverFsu7i3FRm8
+        pMLiba4y3JkeONFm4KzJwN7Idt5FzXs0kGkz1SDN5NPOEg8WHcVYzlLsNuI7nU7Dd8prZkNKMF+m
+        mJdOJNiUW6rfok+vWnmM4YU6iA7uDHVWF6g9vBmb/YJQRWYMejBMTEWApanQpb7IG5pxVROeyjEZ
+        g5EphNIwwlhJahoV8XA47B79o4aT+QPxXM+/0BpOe9J0VG+1EuvMB7F2Slvd1zgFaX44/dUW0EZx
+        Gq1B5xszAPMM4wQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:26:19 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 da0472696f37c3fd9136c0c43a0dc866.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - sFyDtME7m-6OaRyE7rS7ug0WqR-RT26RQilYh1gur1Cdyvr7ek2C3Q==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:26:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6679820b-53f6d90464b6a1993eec97b0;Root=1-6679820b-79b708356730d1f4241df750
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.4.36
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=7982377911
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA63W25KbIBgH8OvuUzDcbxQ8oJ24+wC7nV5sL3rnoJJIg5KAxjZPX2IOMjs7Eyfh
+        TgbB/PL/OCxf/zYC7JnSXLYZRAsfAtaWsuLtOoN9t3pOIHh9eVoqvQW6o10G5QaatuYHpkFJ20JI
+        86YZZp63irfmjVOjkkMrJK3MrGbAt3EEELRgIoMfu54qBsHAq67OIIkgqBlf12bw8VnLXpUsg3XX
+        bfV3zxN8zxbHr/NyJXi5UYtSNl6CSOKRNMEBISlCOWFhWqWUoSjXiz/bNQS9Mt+6TDIMw8Iava1l
+        J7VXcGPdC14oqv5Zs3kj0NM7D4KGVZxmcBwBgfcZ807VmoFPJBSZf+FiGhsPo3auUDNMv+q+KVrK
+        xTWj2MoI+S48nStPdzujj4aKyYKieAoHhy4wjSuMnokBATa/+7yAsG+W6aXaxo6Hq611BWrngsJj
+        VV1AsbV8xo6HQYMr0HAb9MPsGH1z1QTYqrfIhcaVpZlrAfFxmZzTCRGZym3seDidgyvRYbYoseot
+        wmgSjR0Pi0pXovK2aDyCpq06tuJBPg4daApXGjFTA1Bs5YP8EFvn6dh1X0KUksQPKkajvHZlquea
+        sB+ajfq8ilAQmGQuu/ap6z5TSVZlwVBK0nzjyrS5bfr9fLr6BG/WQXRM5noS+cSkdp8pNRe7NKhC
+        vMoDZ6hghuqn4mve0um2gP3YPl0RMZv5fSZTxCxOi4iluXSVk/wqp+Xp+mru6Z65uL88/Qd2E1MH
+        5wsAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:26:19 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 da0472696f37c3fd9136c0c43a0dc866.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - YoMs9umnloEWTy-cvhuNmqcNGG6NVsghjNcYAJVWhgoINyV5jidwug==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:26:19 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-6679820b-56316a997ca722cd40b91c33;Root=1-6679820b-07fbd1ff06be63e7754009a7
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.30.219
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/TestClaims.test_omits_statement_if_no_pageid_tag.yml
+++ b/tests/fixtures/cassettes/TestClaims.test_omits_statement_if_no_pageid_tag.yml
@@ -1,0 +1,212 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=7982377911
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA81XTXPbNhA9x78Cw8z4ZImkSIqkLTkfTZPMNEkzk7SZnjwQCYmoQYIFQCnKrbf8
+        OP+oPoCS5VhOq+jU8dgGsFjs213g7XLy5HMtyJIpzWUz9cJh4BHWFLLkzWLqdWY+yDzy5PJkonRL
+        tKFm6slrD/O2kkYSXk69NM9GUZrmYegRzQrFsCdlcV7mlIWJXVM4f+plYYqz5lTVUy/3SEkN61oh
+        aclwSBjFaRLl2RhbuJ7TpVTcsKkHOIIXrNEYh5hoOmdmfSXYkgknVRKgHHZMoLTgDRVbGEE8YuN8
+        ljDY28rmUtXWjT/bhUeWnK004IxygK9ZyenUc57BxUcTuWqYIo22Xo7DYBQC4tN3wcgjHZxqaA1Q
+        z7l8wZdv+ExRtQYcRsWtoOQusGZNXjO4QxeM3G4UstjghsOFhIN9lJLYhQArfaTGHmmpqa6o4BRI
+        ZxypWYqNOYB8NFnwuSH2zxUTcH8mbKg80rDV1VzIlZ3YfY8mW/FV2SlnWxP/WMnEtxZtkHwXJTsy
+        3Ah22WTR1SoMk2Di9wuQlEwXirfW5uV7JedD8kINycdK1uzm79PHQZRfaPJSSEXJUjbkBeuMLipB
+        m/KM/HrzVRumFONFRbqmJCVy8qGoVox/OSO8IZ+kMk7wnAvsn3c3X92GTjC3/Jp2mlyQmhsyHMIq
+        bpBo3NDa+kQFTidvoSUEU8PhySum6OC3Bqt1ZVXPXw5/HpJf5M3XChvOwiwbD8I8irH1VJgLSirF
+        5tPTvzppLipj2nPf77PU536Tq6FUC7/FFfDjaBTip1fAhREb3UbiHOsorpycS4Hc9XtOF+bioBOB
+        xqd298nJO0aVWBMqBHm84g0jrZJlV7CSLIScYXlNCkRfk7mSNSk6YfiSKk3knPzODdd4GQ0HGjok
+        HxgjiB0i/XhWwRvyf/WanNK6vbC/5CmT4rs4IbvNhvYTsFcQ+xLpsmzwY2n596Nu8zHx774APIgl
+        13zGhaUGrttuBo5zjxbUpzhrwDdgM8uDNRdrN7EvdWI5U5NW4kHc40xDrxk4cBSEo0GQD8KIBNl5
+        lJ7HIBMnWyjadIKChvrz3GLXXDd4vj3NUm261loAkiQPxsE4DuONYTCjoRvABUV9qGvWgEShhykt
+        y5oZUOcWZ+/R95Tg510lTJ1znbYECUkJSLYuuIhgPhMStag31Sq+s6srqnqycwdsUOlLUM/tGOuN
+        tFFzW1omW9BCRXU/2kEGO2tHpxi4sgbCD8I4SAa7+jYYBRniSTtTSVD1tyWhX324KFCw8LNOG8Up
+        ygwtKrzIKxiy5i/BMVYAuqSL/0YQBVGWpQjGcSh+UuvWyAXu1QNIip3wMDRhNBrFwdEhcYyv9yOC
+        soX1AyHEaXpsMMD0NW1Qte+nZNELDkMQxegujsvGe5Q480AAWrd+mPlRaPui4+x/WHHzhSlbaPeD
+        oHfCw5BkcZLk4zw6Fs1bpsyXbYd0hvaAkXdsRf6Q6po8R5vX8IIK8oqqkjX7cGurvSm2pmJof9ZQ
+        nG31Fk7tMEfydJxmyfH3GmXy3Jb66abU3wOLfuz+jh/BdXy6y+KcIwiGzzlazR/oVfYd2D/qgQ4F
+        LY8NwyYKh/k4yqMwT5Ojn5Shn2Uj6/X5jOMfp2L6bT+z78q+xtJ2QNsG6EDY2Ti+e/HHWZQG+Qhf
+        C7ePsy8NPz1zjS7Xhhd4+cqWBiCkBaNs/1IDiZMcBiIL0jhLUA6PY4OPePC2F36P/mIfiumltvk4
+        DE2SZOM8Hd2pDmGGD6hx5MJyG6w+LE/761MxtYvJnS6UvBk+GJxdmsQWlPtvS/mkU6Iv6RgQs25h
+        xn3b2TvpXdrrr9Grr1ar4RzdyrUaomnw3Q696eA3dOLvWgB/4uM0993THz/pNewAn8iXJ/8A3Gfx
+        MlEPAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:31:29 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 7441f523d9aa7a75eb213f3a670e46ac.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - czFHM7c5uX8doskuotL3DMTWR-8NuxM8dg2ZpS1LK0qpWsA_2TWFEg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:31:29 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:31:29 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66798341-7ddd618517b5ea104c3d1856;Root=1-66798341-75006a396b1bae4b3009b6b8
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.19.245
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WUS0/DMBCEz/RXrHyCQ+KWN6gpQq3EBRACIc6usyRWEruynRT49WwfKbRKKGpv
+        yWH8zUoz07/5KHKo0DpldMR6YZcBamlipZOIlf49uGRwM+j0rZuA88JHzGSM/nMlUTt0g85B/Q0q
+        jhjptSgwYrd5Ds8qSb2DZ3RoK4wZlDaPGAO+qTpdqby3alx6cgP3C8RSlXo/cdecS4vCqwqlKQqj
+        XWhswmszfPzJj8MubyCcNxCCRzNCqyq3GyrQcRvtpJmmh2QarVQi35st/8Afb8XverFsu7i3FRm8
+        pMLiba4y3JkeONFm4KzJwN7Idt5FzXs0kGkz1SDN5NPOEg8WHcVYzlLsNuI7nU7Dd8prZkNKMF+m
+        mJdOJNiUW6rfok+vWnmM4YU6iA7uDHVWF6g9vBmb/YJQRWYMejBMTEWApanQpb7IG5pxVROeyjEZ
+        g5EphNIwwlhJahoV8XA47B79o4aT+QPxXM+/0BpOe9J0VG+1EuvMB7F2Slvd1zgFaX44/dUW0EZx
+        Gq1B5xszAPMM4wQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:31:29 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 7441f523d9aa7a75eb213f3a670e46ac.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Cnx4RMloAOs1vVMu0P_ZdCVyaAt6SUFS6_AszPIycbED0IHQtCBrAQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:31:29 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66798341-2bcff8857da0e5d8241e71a7;Root=1-66798341-3d7487e333cadd417a02fee2
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.0.9
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=7982377911
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA63W25KbIBgH8OvuUzDcbxQ8oJ24+wC7nV5sL3rnoJJIg5KAxjZPX2IOMjs7Eyfh
+        TgbB/PL/OCxf/zYC7JnSXLYZRAsfAtaWsuLtOoN9t3pOIHh9eVoqvQW6o10G5QaatuYHpkFJ20JI
+        86YZZp63irfmjVOjkkMrJK3MrGbAt3EEELRgIoMfu54qBsHAq67OIIkgqBlf12bw8VnLXpUsg3XX
+        bfV3zxN8zxbHr/NyJXi5UYtSNl6CSOKRNMEBISlCOWFhWqWUoSjXiz/bNQS9Mt+6TDIMw8Iava1l
+        J7VXcGPdC14oqv5Zs3kj0NM7D4KGVZxmcBwBgfcZ807VmoFPJBSZf+FiGhsPo3auUDNMv+q+KVrK
+        xTWj2MoI+S48nStPdzujj4aKyYKieAoHhy4wjSuMnokBATa/+7yAsG+W6aXaxo6Hq611BWrngsJj
+        VV1AsbV8xo6HQYMr0HAb9MPsGH1z1QTYqrfIhcaVpZlrAfFxmZzTCRGZym3seDidgyvRYbYoseot
+        wmgSjR0Pi0pXovK2aDyCpq06tuJBPg4daApXGjFTA1Bs5YP8EFvn6dh1X0KUksQPKkajvHZlquea
+        sB+ajfq8ilAQmGQuu/ap6z5TSVZlwVBK0nzjyrS5bfr9fLr6BG/WQXRM5noS+cSkdp8pNRe7NKhC
+        vMoDZ6hghuqn4mve0um2gP3YPl0RMZv5fSZTxCxOi4iluXSVk/wqp+Xp+mru6Z65uL88/Qd2E1MH
+        5wsAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:31:29 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 7441f523d9aa7a75eb213f3a670e46ac.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dF7Al_C_uYs7rxaatE3TZiFPf_V7Qgxmusl4uSA2VB26DLVofNXBjQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:31:29 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-66798341-434d176405ee2fa53bc3105c;Root=1-66798341-506e3f814cb873ef54027f2d
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.0.9
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/TestClaims.test_omits_statement_if_not_bhl_user.yml
+++ b/tests/fixtures/cassettes/TestClaims.test_omits_statement_if_not_bhl_user.yml
@@ -1,0 +1,212 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&photo_id=7982377911
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA81XTXPbNhA9x78Cw8z4ZImkSIqkLTkfTZPMNEkzk7SZnjwQCYmoQYIFQCnKrbf8
+        OP+oPoCS5VhOq+jU8dgGsFjs213g7XLy5HMtyJIpzWUz9cJh4BHWFLLkzWLqdWY+yDzy5PJkonRL
+        tKFm6slrD/O2kkYSXk69NM9GUZrmYegRzQrFsCdlcV7mlIWJXVM4f+plYYqz5lTVUy/3SEkN61oh
+        aclwSBjFaRLl2RhbuJ7TpVTcsKkHOIIXrNEYh5hoOmdmfSXYkgknVRKgHHZMoLTgDRVbGEE8YuN8
+        ljDY28rmUtXWjT/bhUeWnK004IxygK9ZyenUc57BxUcTuWqYIo22Xo7DYBQC4tN3wcgjHZxqaA1Q
+        z7l8wZdv+ExRtQYcRsWtoOQusGZNXjO4QxeM3G4UstjghsOFhIN9lJLYhQArfaTGHmmpqa6o4BRI
+        ZxypWYqNOYB8NFnwuSH2zxUTcH8mbKg80rDV1VzIlZ3YfY8mW/FV2SlnWxP/WMnEtxZtkHwXJTsy
+        3Ah22WTR1SoMk2Di9wuQlEwXirfW5uV7JedD8kINycdK1uzm79PHQZRfaPJSSEXJUjbkBeuMLipB
+        m/KM/HrzVRumFONFRbqmJCVy8qGoVox/OSO8IZ+kMk7wnAvsn3c3X92GTjC3/Jp2mlyQmhsyHMIq
+        bpBo3NDa+kQFTidvoSUEU8PhySum6OC3Bqt1ZVXPXw5/HpJf5M3XChvOwiwbD8I8irH1VJgLSirF
+        5tPTvzppLipj2nPf77PU536Tq6FUC7/FFfDjaBTip1fAhREb3UbiHOsorpycS4Hc9XtOF+bioBOB
+        xqd298nJO0aVWBMqBHm84g0jrZJlV7CSLIScYXlNCkRfk7mSNSk6YfiSKk3knPzODdd4GQ0HGjok
+        HxgjiB0i/XhWwRvyf/WanNK6vbC/5CmT4rs4IbvNhvYTsFcQ+xLpsmzwY2n596Nu8zHx774APIgl
+        13zGhaUGrttuBo5zjxbUpzhrwDdgM8uDNRdrN7EvdWI5U5NW4kHc40xDrxk4cBSEo0GQD8KIBNl5
+        lJ7HIBMnWyjadIKChvrz3GLXXDd4vj3NUm261loAkiQPxsE4DuONYTCjoRvABUV9qGvWgEShhykt
+        y5oZUOcWZ+/R95Tg510lTJ1znbYECUkJSLYuuIhgPhMStag31Sq+s6srqnqycwdsUOlLUM/tGOuN
+        tFFzW1omW9BCRXU/2kEGO2tHpxi4sgbCD8I4SAa7+jYYBRniSTtTSVD1tyWhX324KFCw8LNOG8Up
+        ygwtKrzIKxiy5i/BMVYAuqSL/0YQBVGWpQjGcSh+UuvWyAXu1QNIip3wMDRhNBrFwdEhcYyv9yOC
+        soX1AyHEaXpsMMD0NW1Qte+nZNELDkMQxegujsvGe5Q480AAWrd+mPlRaPui4+x/WHHzhSlbaPeD
+        oHfCw5BkcZLk4zw6Fs1bpsyXbYd0hvaAkXdsRf6Q6po8R5vX8IIK8oqqkjX7cGurvSm2pmJof9ZQ
+        nG31Fk7tMEfydJxmyfH3GmXy3Jb66abU3wOLfuz+jh/BdXy6y+KcIwiGzzlazR/oVfYd2D/qgQ4F
+        LY8NwyYKh/k4yqMwT5Ojn5Shn2Uj6/X5jOMfp2L6bT+z78q+xtJ2QNsG6EDY2Ti+e/HHWZQG+Qhf
+        C7ePsy8NPz1zjS7Xhhd4+cqWBiCkBaNs/1IDiZMcBiIL0jhLUA6PY4OPePC2F36P/mIfiumltvk4
+        DE2SZOM8Hd2pDmGGD6hx5MJyG6w+LE/761MxtYvJnS6UvBk+GJxdmsQWlPtvS/mkU6Iv6RgQs25h
+        xn3b2TvpXdrrr9Grr1ar4RzdyrUaomnw3Q696eA3dOLvWgB/4uM0993THz/pNewAn8iXJ/8A3Gfx
+        MlEPAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:29:56 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 55bef38e734117ff8ff4a83214717dc8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - Du5BC5ePJD770i-DBcEvHZkVvQ0XMNf43fTtCHrLC5asWCokT-5Tbg==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:29:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:29:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-667982e4-290c8c8a4f2568e800ceedf0;Root=1-667982e4-1383b54c1ad29888742dcae3
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.30.14
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.licenses.getInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WUS0/DMBCEz/RXrHyCQ+KWN6gpQq3EBRACIc6usyRWEruynRT49WwfKbRKKGpv
+        yWH8zUoz07/5KHKo0DpldMR6YZcBamlipZOIlf49uGRwM+j0rZuA88JHzGSM/nMlUTt0g85B/Q0q
+        jhjptSgwYrd5Ds8qSb2DZ3RoK4wZlDaPGAO+qTpdqby3alx6cgP3C8RSlXo/cdecS4vCqwqlKQqj
+        XWhswmszfPzJj8MubyCcNxCCRzNCqyq3GyrQcRvtpJmmh2QarVQi35st/8Afb8XverFsu7i3FRm8
+        pMLiba4y3JkeONFm4KzJwN7Idt5FzXs0kGkz1SDN5NPOEg8WHcVYzlLsNuI7nU7Dd8prZkNKMF+m
+        mJdOJNiUW6rfok+vWnmM4YU6iA7uDHVWF6g9vBmb/YJQRWYMejBMTEWApanQpb7IG5pxVROeyjEZ
+        g5EphNIwwlhJahoV8XA47B79o4aT+QPxXM+/0BpOe9J0VG+1EuvMB7F2Slvd1zgFaX44/dUW0EZx
+        Gq1B5xszAPMM4wQAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:29:56 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 55bef38e734117ff8ff4a83214717dc8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - GhjTHt190YQo0Xy1UeNdzEdutKvWV5SFr4Ch9T5VYHQI0PQlJyeUGA==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:29:56 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-667982e4-67cf0f8d650e0d9b233b6e3d;Root=1-667982e4-4e9ce81953133e5a120cc9fe
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.45.7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D
+      host:
+      - api.flickr.com
+      user-agent:
+      - Flickypedia/dev (https://commons.wikimedia.org/wiki/Commons:Flickypedia; hello@flickr.org)
+    method: GET
+    uri: https://api.flickr.com/services/rest/?method=flickr.photos.getSizes&photo_id=7982377911
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA63W25KbIBgH8OvuUzDcbxQ8oJ24+wC7nV5sL3rnoJJIg5KAxjZPX2IOMjs7Eyfh
+        TgbB/PL/OCxf/zYC7JnSXLYZRAsfAtaWsuLtOoN9t3pOIHh9eVoqvQW6o10G5QaatuYHpkFJ20JI
+        86YZZp63irfmjVOjkkMrJK3MrGbAt3EEELRgIoMfu54qBsHAq67OIIkgqBlf12bw8VnLXpUsg3XX
+        bfV3zxN8zxbHr/NyJXi5UYtSNl6CSOKRNMEBISlCOWFhWqWUoSjXiz/bNQS9Mt+6TDIMw8Iava1l
+        J7VXcGPdC14oqv5Zs3kj0NM7D4KGVZxmcBwBgfcZ807VmoFPJBSZf+FiGhsPo3auUDNMv+q+KVrK
+        xTWj2MoI+S48nStPdzujj4aKyYKieAoHhy4wjSuMnokBATa/+7yAsG+W6aXaxo6Hq611BWrngsJj
+        VV1AsbV8xo6HQYMr0HAb9MPsGH1z1QTYqrfIhcaVpZlrAfFxmZzTCRGZym3seDidgyvRYbYoseot
+        wmgSjR0Pi0pXovK2aDyCpq06tuJBPg4daApXGjFTA1Bs5YP8EFvn6dh1X0KUksQPKkajvHZlquea
+        sB+ajfq8ilAQmGQuu/ap6z5TSVZlwVBK0nzjyrS5bfr9fLr6BG/WQXRM5noS+cSkdp8pNRe7NKhC
+        vMoDZ6hghuqn4mve0um2gP3YPl0RMZv5fSZTxCxOi4iluXSVk/wqp+Xp+mru6Z65uL88/Qd2E1MH
+        5wsAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/xml; charset=utf-8
+      Date:
+      - Mon, 24 Jun 2024 14:29:57 GMT
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 55bef38e734117ff8ff4a83214717dc8.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - ULG_SYfllbe3OUZbcJDM_4a6svMA-LkkgpBBLkLJEPEg2yjDAJKeZQ==
+      X-Amz-Cf-Pop:
+      - LHR5-P1
+      X-Cache:
+      - Miss from cloudfront
+      content-encoding:
+      - gzip
+      server:
+      - openresty
+      set-cookie:
+      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Wed, 24-Jul-2024 14:29:57 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      vary:
+      - Accept-Encoding
+      x-flickr-api-request:
+      - Self=1-667982e5-3af503052da4fad15b998117;Root=1-667982e5-4b94e78a74eaf4d63698bd85
+      x-robots-tag:
+      - noindex
+      x-server:
+      - serverless-proxy-10.78.4.36
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/structured_data/statements/test_bhl_page_id_statement.py
+++ b/tests/structured_data/statements/test_bhl_page_id_statement.py
@@ -1,6 +1,7 @@
 import pytest
 
 from flickypedia.structured_data.statements.bhl_page_id_statement import (
+    create_bhl_page_id_statement,
     guess_bhl_page_id,
 )
 
@@ -52,3 +53,27 @@ from flickypedia.structured_data.statements.bhl_page_id_statement import (
 )
 def test_guess_bhl_page_id(photo_id: str, tags: list[str], page_id: str | None) -> None:
     assert guess_bhl_page_id(photo_id=photo_id, tags=tags) == page_id
+
+
+def test_creates_bhl_page_id_statement() -> None:
+    statement = create_bhl_page_id_statement(
+        photo_id="7982377911", tags=["austria", "cryptogamia", "bhl:page=4321212"]
+    )
+
+    assert statement == {
+        "mainsnak": {
+            "datavalue": {"value": "4321212", "type": "string"},
+            "property": "P687",
+            "snaktype": "value",
+        },
+        "type": "statement",
+    }
+
+
+def test_does_not_create_bhl_page_id_statement_if_no_pageid() -> None:
+    statement = create_bhl_page_id_statement(
+        photo_id="5665412449",
+        tags=["taxonomy:binomial=aegothelessavesi", "twitterpost"],
+    )
+
+    assert statement is None

--- a/tests/structured_data/statements/test_bhl_page_id_statement.py
+++ b/tests/structured_data/statements/test_bhl_page_id_statement.py
@@ -1,0 +1,54 @@
+import pytest
+
+from flickypedia.structured_data.statements.bhl_page_id_statement import (
+    guess_bhl_page_id,
+)
+
+
+@pytest.mark.parametrize(
+    ["photo_id", "tags", "page_id"],
+    [
+        (
+            "51281775881",
+            ["periodicals", "physicalsciences", "bhl:page=33665645"],
+            "33665645",
+        ),
+        (
+            "51269075642",
+            [
+                "england",
+                "paleontology",
+                "bhl:page=61831901",
+            ],
+            "61831901",
+        ),
+        (
+            "49841872056",
+            ["salamanders", "earlyworks", "bhl:page=52948312"],
+            "52948312",
+        ),
+        (
+            "46016620675",
+            ["australia", "newsouthwales", "bhl:page=54052811"],
+            "54052811",
+        ),
+        (
+            "36561149543",
+            ["bhl:page=53071515", "butterflies", "insects"],
+            "53071515",
+        ),
+        (
+            "7982377911",
+            ["austria", "cryptogamia", "bhl:page=4321212"],
+            "4321212",
+        ),
+        ("5665412449", ["taxonomy:binomial=aegothelessavesi", "twitterpost"], None),
+        (
+            "5984633427",
+            ["indonesia", "mammals", "bhl:page=34021551", "bhl:page=34551619"],
+            None,
+        ),
+    ],
+)
+def test_guess_bhl_page_id(photo_id: str, tags: list[str], page_id: str | None) -> None:
+    assert guess_bhl_page_id(photo_id=photo_id, tags=tags) == page_id


### PR DESCRIPTION
This is part of https://github.com/Flickr-Foundation/flickypedia/issues/465