### PR TITLE
Add custom 404 and 401 error pages

### DIFF
--- a/src/flickypedia/uploadr/__init__.py
+++ b/src/flickypedia/uploadr/__init__.py
@@ -44,6 +44,7 @@ from .views import (
     post_user_comment_api,
     post_comments,
     prepare_info,
+    register_views,
     say_thanks,
     select_photos,
     truncate_description,
@@ -121,6 +122,8 @@ def create_app(
     app.add_url_rule(
         "/toolinfo.json", view_func=lambda: send_file("static/toolinfo.json")
     )
+
+    register_views(app)
 
     app.jinja_env.filters["html_unescape"] = html.unescape
     app.jinja_env.filters["size_at"] = size_at

--- a/src/flickypedia/uploadr/static/assets/header.scss
+++ b/src/flickypedia/uploadr/static/assets/header.scss
@@ -24,10 +24,6 @@ header {
     margin-top:    auto;
     margin-bottom: auto;
   }
-
-  div.logo a:hover {
-    background: none;
-  }
 }
 
 nav {

--- a/src/flickypedia/uploadr/static/assets/mixins.scss
+++ b/src/flickypedia/uploadr/static/assets/mixins.scss
@@ -2,7 +2,9 @@
   color: $color;
 
   &:hover {
-    background: rgba($color, $opacity);
+    text-decoration: underline;
+    text-decoration-thickness: 4px;
+    text-decoration-skip-ink: none;
   }
 }
 
@@ -31,6 +33,7 @@
 
   &:hover {
     background: darken($color, 15%);
+    text-decoration: none !important;
   }
 
   &:active {

--- a/src/flickypedia/uploadr/static/assets/style.scss
+++ b/src/flickypedia/uploadr/static/assets/style.scss
@@ -103,6 +103,10 @@ a {
   @include link_styles($blue, 0.3);
 }
 
+svg a, svg a:hover {
+  text-decoration: none;
+}
+
 input[type="url"],
 input[type="text"],
 select,

--- a/src/flickypedia/uploadr/static/assets/style.scss
+++ b/src/flickypedia/uploadr/static/assets/style.scss
@@ -289,6 +289,15 @@ img {
   max-width: 100%;
 }
 
+figure {
+  margin: 0;
+}
+
+figcaption, figcaption a {
+  color: $grey;
+  font-size: small;
+}
+
 .flashes {
   color: $red;
 }

--- a/src/flickypedia/uploadr/templates/base.html
+++ b/src/flickypedia/uploadr/templates/base.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
-    <title>{% if title is defined %}{{ title }} – {% endif %}flickypedia</title>
+    <title>{% if title is defined %}{{ title }} – {% endif %}Flickypedia</title>
 
     <link rel="stylesheet" href="{{ url_for('static', filename='phk3iud.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/src/flickypedia/uploadr/templates/components/homepage_how_it_works_landscape.svg
+++ b/src/flickypedia/uploadr/templates/components/homepage_how_it_works_landscape.svg
@@ -10,7 +10,7 @@
 
 <svg viewBox="0 0 485 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <style>
+    <style>      
       rect.next_step {
         fill: currentColor;
       }

--- a/src/flickypedia/uploadr/templates/not_found.html
+++ b/src/flickypedia/uploadr/templates/not_found.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% set title = "404 Not Found" %}
+
+{% block content %}
+  {% include "components/header.html" %}
+
+  <h1>404 Not Found</h1>
+
+  <p>
+    We looked far and wide for that page, but we couldn’t find anything!
+  </p>
+  
+  <p>
+    If you were expecting to see something here, please email us at <a href="mailto:hello@flickr.org">hello@flickr.org</a>.
+  </p>
+  
+  <figure>
+    <a href="https://commons.wikimedia.org/wiki/File:Telescope-123.jpg">
+      <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Telescope-123.jpg/1280px-Telescope-123.jpg">
+    </a>
+    <figcaption>
+      Telescope in Big Hill, NSW.
+      Photograph by Ryan Wick.
+      From <a href="https://commons.wikimedia.org/wiki/File:Telescope-123.jpg">Wikimedia Commons</a>, used under CC&nbsp;BY&nbsp;2.0.
+    </figcaption>
+  </figure>
+{% endblock %}

--- a/src/flickypedia/uploadr/templates/unauthorized.html
+++ b/src/flickypedia/uploadr/templates/unauthorized.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% set title = "401 Unauthorized" %}
+
+{% block content %}
+  {% include "components/header.html" %}
+
+  <h1>401 Unauthorized</h1>
+
+  <p>
+    Something went wrong logging in to Wikimedia Commons!
+    Please try <a href="{{ url_for('oauth2_authorize_wikimedia') }}">logging in</a> again.
+  </p>
+  
+  <p>
+    If the problem persists, please email us at <a href="mailto:hello@flickr.org">hello@flickr.org</a>.
+  </p>
+  
+  <figure>
+    <a href="https://commons.wikimedia.org/wiki/File:Moor_Street_Station_-_No_Unauthorised_persons_allowed_beyond_this_point_(5269054535).jpg">
+      <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/97/Moor_Street_Station_-_No_Unauthorised_persons_allowed_beyond_this_point_%285269054535%29.jpg/1280px-Moor_Street_Station_-_No_Unauthorised_persons_allowed_beyond_this_point_%285269054535%29.jpg">
+    </a>
+    <figcaption>
+      A “no unauthorised persons” sign at Moor Street railway station, Birmingham, UK.
+      Photograph by Elliott Brown.
+      From <a href="https://commons.wikimedia.org/wiki/File:Moor_Street_Station_-_No_Unauthorised_persons_allowed_beyond_this_point_(5269054535).jpg">Wikimedia Commons</a>, used under CC&nbsp;BY&nbsp;2.0.
+    </figcaption>
+  </figure>
+{% endblock %}

--- a/src/flickypedia/uploadr/views/__init__.py
+++ b/src/flickypedia/uploadr/views/__init__.py
@@ -1,10 +1,11 @@
-from flask import render_template
+from flask import Flask, render_template
 
 from .api import (
     find_matching_categories_api,
     find_matching_languages_api,
     validate_title_api,
 )
+from . import errors
 from .get_photos import get_photos
 from .keep_going import keep_going
 from .post_comments import post_comments, post_bot_comment_api, post_user_comment_api
@@ -31,6 +32,10 @@ def faqs() -> str:
     return render_template("faqs.html", current_step=None)
 
 
+def register_views(app: Flask) -> None:
+    app.register_error_handler(404, errors.not_found)
+
+
 __all__ = [
     "about",
     "bookmarklet",
@@ -46,6 +51,7 @@ __all__ = [
     "post_user_comment_api",
     "post_comments",
     "prepare_info",
+    "register_views",
     "say_thanks",
     "select_photos",
     "truncate_description",

--- a/src/flickypedia/uploadr/views/__init__.py
+++ b/src/flickypedia/uploadr/views/__init__.py
@@ -33,6 +33,7 @@ def faqs() -> str:
 
 
 def register_views(app: Flask) -> None:
+    app.register_error_handler(401, errors.unauthorized)
     app.register_error_handler(404, errors.not_found)
 
 

--- a/src/flickypedia/uploadr/views/errors.py
+++ b/src/flickypedia/uploadr/views/errors.py
@@ -1,0 +1,5 @@
+from flask import render_template
+
+
+def not_found(e: Exception) -> tuple[str, int]:
+    return render_template("not_found.html"), 404

--- a/src/flickypedia/uploadr/views/errors.py
+++ b/src/flickypedia/uploadr/views/errors.py
@@ -1,5 +1,9 @@
 from flask import render_template
 
 
+def unauthorized(e: Exception) -> tuple[str, int]:
+    return render_template("unauthorized.html"), 401
+
+
 def not_found(e: Exception) -> tuple[str, int]:
     return render_template("not_found.html"), 404

--- a/tests/uploadr/test_app.py
+++ b/tests/uploadr/test_app.py
@@ -43,3 +43,11 @@ def test_gets_toolinfo_json(client: FlaskClient) -> None:
     json.loads(resp.data)
 
     resp.close()
+
+
+class TestErrorPages:
+    def test_404_page(self, client: FlaskClient) -> None:
+        resp = client.get("/404/")
+
+        assert resp.status_code == 404
+        assert b"<h1>404 Not Found</h1>" in resp.data

--- a/tests/uploadr/test_app.py
+++ b/tests/uploadr/test_app.py
@@ -46,6 +46,12 @@ def test_gets_toolinfo_json(client: FlaskClient) -> None:
 
 
 class TestErrorPages:
+    def test_401_page(self, client: FlaskClient) -> None:
+        resp = client.get("/callback/wikimedia?code=badcode")
+
+        assert resp.status_code == 401
+        assert b"<h1>401 Unauthorized</h1>" in resp.data
+
     def test_404_page(self, client: FlaskClient) -> None:
         resp = client.get("/404/")
 


### PR DESCRIPTION
This should help us hear about issues like #478 faster – it directs people to email us if they can't log into Flickypedia.