### PR TITLE
Filter out null coordinates written with *any* accuracy

### DIFF
--- a/src/flickypedia/structured_data/statements/location_statement.py
+++ b/src/flickypedia/structured_data/statements/location_statement.py
@@ -31,7 +31,7 @@ def create_location_statement(location: LocationInfo | None) -> NewStatement | N
     # than write null coordinates into WMC.
     #
     # See https://github.com/Flickr-Foundation/flickypedia/issues/461
-    if location == {"accuracy": 16, "latitude": 0.0, "longitude": 0.0}:
+    if location["latitude"] == 0.0 and location["longitude"] == 0.0:
         return None
 
     # The accuracy parameter in the Flickr API response tells us

--- a/tests/structured_data/statements/test_location_statement.py
+++ b/tests/structured_data/statements/test_location_statement.py
@@ -66,12 +66,20 @@ def test_no_location_statement_if_no_location_data() -> None:
     assert create_location_statement(location=None) is None
 
 
-def test_no_location_statement_if_null_location_data() -> None:
+@pytest.mark.parametrize(
+    "location",
+    [
+        # From https://www.flickr.com/photos/ed_webster/16125227798/
+        # Retrieved 23 June 2024
+        {"accuracy": 16, "latitude": 0.0, "longitude": 0.0},
+        #
+        # From https://www.flickr.com/photos/27526357@N00/3689541075/
+        # Retrieved 10 July 2024
+        {"accuracy": 12, "latitude": 0.0, "longitude": 0.0},
+    ],
+)
+def test_no_location_statement_if_null_location_data(location: LocationInfo) -> None:
     """
     Regression test for https://github.com/Flickr-Foundation/flickypedia/issues/461
     """
-    # From https://www.flickr.com/photos/ed_webster/16125227798/
-    # Retrieved 23 June 2024
-    location: LocationInfo = {"accuracy": 16, "latitude": 0.0, "longitude": 0.0}
-
     assert create_location_statement(location=location) is None


### PR DESCRIPTION
Previously we were only filtering out null coordinates with `accuracy=16`, but actually they can occur at any accuracy level.  We should ignore the accuracy for the purposes of detecting whether some coordinates are null.

h/t WMC user HenkvD for spotting this:
https://commons.wikimedia.org/wiki/User_talk:FlickypediaBackfillrBot#c-HenkvD-20240709145200-Alexwlchan-20240624084500