### PR TITLE
Add `interrogate` to the project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,17 @@ jobs:
     - name: Install dependencies
       run: pip install -r dev_requirements.txt
 
-    - name: Run linting
+    - name: Check formatting
       run: |
         ruff check .
         ruff format --check .
 
+    - name: Check docstrings
+      run: interrogate -vv
+
     - name: Check types
       run: mypy src tests
+
     - name: Run tests
       run: |
         coverage run -m pytest tests

--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -3,6 +3,7 @@
 
 pywikibot
 
+interrogate
 mypy
 pytest-cov
 ruff

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -12,6 +12,8 @@ anyio==4.9.0
     #   -r requirements.txt
     #   flickypedia
     #   httpx
+attrs==25.3.0
+    # via interrogate
 authlib==1.5.2
     # via
     #   -r requirements.txt
@@ -49,6 +51,9 @@ click==8.1.8
     #   -r requirements.txt
     #   flask
     #   flickypedia
+    #   interrogate
+colorama==0.4.6
+    # via interrogate
 coverage==7.8.0
     # via pytest-cov
 cryptography==44.0.2
@@ -120,6 +125,8 @@ idna==3.10
     #   yarl
 iniconfig==2.1.0
     # via pytest
+interrogate==1.7.0
+    # via -r dev_requirements.in
 itsdangerous==2.2.0
     # via
     #   -r requirements.txt
@@ -187,6 +194,8 @@ pluggy==1.5.0
     # via pytest
 propcache==0.3.1
     # via yarl
+py==1.11.0
+    # via interrogate
 pycparser==2.22
     # via
     #   -r requirements.txt
@@ -233,6 +242,8 @@ sqlalchemy==2.0.40
     #   -r requirements.txt
     #   flask-sqlalchemy
     #   flickypedia
+tabulate==0.9.0
+    # via interrogate
 tenacity==9.1.2
     # via
     #   -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,8 @@ filterwarnings = ["error"]
 [tool.mypy]
 mypy_path = "src"
 strict = true
+
+[tool.interrogate]
+# fail_under = 100
+fail_under = 27
+omit-covered-files = true


### PR DESCRIPTION
This makes Flickypedia consistent with our other projects, where we check for docstring coverage. It's quite low right now, but if we work on Flickypedia again we can use it as a ratchet to improve our coverage.