### PR TITLE
Convert to using `from datetime import datetime` everywhere

### DIFF
--- a/src/flickypedia/apis/flickr/by_url.py
+++ b/src/flickypedia/apis/flickr/by_url.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 from flask import current_app
 from flickr_photos_api import FlickrApi
@@ -11,7 +11,7 @@ def get_photos_from_flickr(parsed_url: ParseResult) -> GetPhotosData:
     """
     Get a collection of photos from Flickr.
     """
-    retrieved_at = datetime.datetime.now()
+    retrieved_at = datetime.now(tz=timezone.utc)
 
     api = FlickrApi.with_api_key(
         api_key=current_app.config["FLICKR_API_KEY"],

--- a/src/flickypedia/apis/wikitext.py
+++ b/src/flickypedia/apis/wikitext.py
@@ -12,7 +12,7 @@ need to put in much text ourself.
 
 """
 
-import datetime
+from datetime import datetime, timezone
 
 from flickr_photos_api import SinglePhoto
 
@@ -87,7 +87,7 @@ def create_wikitext(
         "}}"
     ) % (
         wikimedia_username,
-        datetime.datetime.now().strftime("%Y-%m-%d"),
+        datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"),
         photo["owner"]["username"],
         photo["owner"]["profile_url"],
         photo["url"],

--- a/src/flickypedia/fs_queue.py
+++ b/src/flickypedia/fs_queue.py
@@ -19,7 +19,7 @@ the filesystem.  See the comments in ``process_single_task()``.
 # Check this isn't a ecurity gap!
 
 import abc
-import datetime
+from datetime import datetime, timezone
 import json
 import logging
 import os
@@ -40,7 +40,7 @@ State = typing.Literal["waiting", "in_progress", "failed", "completed"]
 
 
 class TaskEvent(typing.TypedDict):
-    time: datetime.datetime
+    time: datetime
     description: str
 
 
@@ -222,7 +222,10 @@ class AbstractFilesystemTaskQueue(abc.ABC, typing.Generic[In, Out]):
             task={
                 "id": task_id,
                 "events": [
-                    {"time": datetime.datetime.now(), "description": "Task created"}
+                    {
+                        "time": datetime.now(tz=timezone.utc),
+                        "description": "Task created",
+                    }
                 ],
                 "state": "waiting",
                 "task_input": task_input,
@@ -243,7 +246,9 @@ class AbstractFilesystemTaskQueue(abc.ABC, typing.Generic[In, Out]):
         if state is not None:
             task["state"] = state
 
-        task["events"].append({"time": datetime.datetime.now(), "description": event})
+        task["events"].append(
+            {"time": datetime.now(tz=timezone.utc), "description": event}
+        )
 
         self.write_task(task)
 

--- a/src/flickypedia/photos.py
+++ b/src/flickypedia/photos.py
@@ -2,7 +2,7 @@
 Some methods for working with collections of photos.
 """
 
-import datetime
+from datetime import datetime
 import typing
 
 from flask import current_app
@@ -105,7 +105,7 @@ class EnrichedPhoto(typing.TypedDict):
 
 
 def enrich_photo(
-    photos: list[SinglePhoto], wikimedia_username: str, retrieved_at: datetime.datetime
+    photos: list[SinglePhoto], wikimedia_username: str, retrieved_at: datetime
 ) -> list[EnrichedPhoto]:
     """
     Create a list of photos which includes their structured data.

--- a/src/flickypedia/structured_data/claims.py
+++ b/src/flickypedia/structured_data/claims.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import typing
 
 from flickr_photos_api import SinglePhoto
@@ -22,7 +22,7 @@ def _create_sdc_claims_for_flickr_photo(
     photo: SinglePhoto,
     *,
     mode: typing.Literal["new_photo", "existing_photo"],
-    retrieved_at: datetime.datetime | None = None,
+    retrieved_at: datetime | None = None,
 ) -> NewClaims:
     """
     Creates a complete structured data claim for a Flickr photo.
@@ -112,7 +112,7 @@ def _create_sdc_claims_for_flickr_photo(
 
 
 def create_sdc_claims_for_new_flickr_photo(
-    photo: SinglePhoto, retrieved_at: datetime.datetime
+    photo: SinglePhoto, retrieved_at: datetime
 ) -> NewClaims:
     """
     Create the SDC claims for a new upload to Wikimedia Commons.

--- a/src/flickypedia/structured_data/statements/published_in_statement.py
+++ b/src/flickypedia/structured_data/statements/published_in_statement.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from ..types import (
     NewStatement,
@@ -10,7 +10,7 @@ from ..wikidata_entities import WikidataEntities
 from ..wikidata_properties import WikidataProperties
 
 
-def create_published_in_statement(date_posted: datetime.datetime) -> NewStatement:
+def create_published_in_statement(date_posted: datetime) -> NewStatement:
     """
     Create a "Published In" statement for the date a photo was posted
     to Flickr.

--- a/src/flickypedia/structured_data/statements/source_statement.py
+++ b/src/flickypedia/structured_data/statements/source_statement.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from ..types import (
     NewStatement,
@@ -14,7 +14,7 @@ def create_source_statement(
     photo_id: str,
     photo_url: str,
     original_url: str | None,
-    retrieved_at: datetime.datetime | None,
+    retrieved_at: datetime | None,
 ) -> NewStatement:
     """
     Create a structured data statement for the "source" statement.

--- a/src/flickypedia/structured_data/types/qualifiers.py
+++ b/src/flickypedia/structured_data/types/qualifiers.py
@@ -34,7 +34,7 @@ the required JSON.
 
 """
 
-import datetime
+from datetime import datetime
 import typing
 
 from .wikidata_datamodel import DataValue, Qualifiers
@@ -57,7 +57,7 @@ class QualifierValueTypes:
         {
             "type": typing.Literal["date"],
             "property": str,
-            "date": datetime.datetime,
+            "date": datetime,
             "precision": typing.Literal["day", "month", "year"],
         },
     )

--- a/src/flickypedia/structured_data/types/wikidata_values.py
+++ b/src/flickypedia/structured_data/types/wikidata_values.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import re
 import typing
 
@@ -19,7 +19,7 @@ class WikidataDatePrecision:
 
 
 def to_wikidata_date_value(
-    d: datetime.datetime, *, precision: typing.Literal["day", "month", "year"]
+    d: datetime, *, precision: typing.Literal["day", "month", "year"]
 ) -> DataValueTypes.Time:
     """
     Convert a Python native-datetime to the Wikidata data model.
@@ -128,13 +128,13 @@ def render_wikidata_date(value: Value.Time) -> str:
     #
     # See https://www.wikidata.org/wiki/Help:Dates#Precision
     if value["precision"] == 11:
-        d = datetime.datetime.strptime(value["time"], "+%Y-%m-%dT00:00:00Z")
+        d = datetime.strptime(value["time"], "+%Y-%m-%dT00:00:00Z")
         return d.strftime("%-d %B %Y")
     elif value["precision"] == 10:
-        d = datetime.datetime.strptime(value["time"], "+%Y-%m-00T00:00:00Z")
+        d = datetime.strptime(value["time"], "+%Y-%m-00T00:00:00Z")
         return d.strftime("%B %Y")
     elif value["precision"] == 9:
-        d = datetime.datetime.strptime(value["time"], "+%Y-00-00T00:00:00Z")
+        d = datetime.strptime(value["time"], "+%Y-00-00T00:00:00Z")
         return d.strftime("%Y")
     else:  # pragma: no cover
         assert False

--- a/src/flickypedia/types/flickr.py
+++ b/src/flickypedia/types/flickr.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import typing
 
 from flickr_photos_api import (
@@ -12,7 +12,7 @@ from flickr_photos_api import (
 
 
 class RetrievedAtMixin(typing.TypedDict):
-    retrieved_at: datetime.datetime
+    retrieved_at: datetime
 
 
 class SinglePhotoData(RetrievedAtMixin):

--- a/src/flickypedia/uploadr/auth/wikimedia.py
+++ b/src/flickypedia/uploadr/auth/wikimedia.py
@@ -59,7 +59,7 @@ it should be accessing it via ``current_user``.
 
 """
 
-import datetime
+from datetime import datetime, timezone
 import json
 import textwrap
 import typing
@@ -450,7 +450,7 @@ def oauth2_callback_wikimedia() -> ViewResponse:
         userid=userinfo["id"],
         name=userinfo["name"],
         encrypted_token=encrypt_string(key, plaintext=json.dumps(token)),
-        first_login=datetime.datetime.now(),
+        first_login=datetime.now(tz=timezone.utc),
     )
     user_db.session.add(user)
     user_db.session.commit()

--- a/src/flickypedia/uploadr/caching.py
+++ b/src/flickypedia/uploadr/caching.py
@@ -13,7 +13,7 @@ the cached response later, to give Flickypedia users a consistent
 view of Flickr data.
 """
 
-import datetime
+from datetime import datetime, timezone
 import json
 import os
 import uuid
@@ -48,7 +48,7 @@ def save_cached_photos_data(photos_data: GetPhotosData) -> str:
     os.makedirs(cache_dir, exist_ok=True)
 
     out_data = {
-        "saved_at": datetime.datetime.now(),
+        "saved_at": datetime.now(tz=timezone.utc),
         "value": photos_data,
     }
 

--- a/src/flickypedia/uploadr/views/prepare_info.py
+++ b/src/flickypedia/uploadr/views/prepare_info.py
@@ -13,7 +13,7 @@ This page gets two arguments as query parameters:
 
 """
 
-import datetime
+from datetime import datetime
 import json
 import typing
 
@@ -188,7 +188,7 @@ class PhotoForUpload(typing.TypedDict):
     categories: list[str]
     license_id: str
     date_taken: DateTaken
-    date_posted: datetime.datetime
+    date_posted: datetime
     original_url: str
     photo_url: str
     sdc: NewClaims

--- a/tests/apis/test_wikitext.py
+++ b/tests/apis/test_wikitext.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 import pathlib
 import textwrap
 
@@ -15,7 +15,10 @@ def tidy(s: str) -> str:
 
 
 def today() -> str:
-    return datetime.datetime.now().strftime("%Y-%m-%d")
+    """
+    Returns the current time as a YYYY-MM-DD string, e.g. 2025-04-28
+    """
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
 
 
 def test_create_wikitext_for_photo() -> None:

--- a/tests/structured_data/statements/test_bhl_page_id_statement.py
+++ b/tests/structured_data/statements/test_bhl_page_id_statement.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 from flickr_photos_api import FlickrApi, MachineTags
 import pytest
@@ -91,7 +91,7 @@ class TestClaims:
         assert statement is not None
 
         claims = create_sdc_claims_for_new_flickr_photo(
-            photo, retrieved_at=datetime.datetime.now()
+            photo, retrieved_at=datetime.now(tz=timezone.utc)
         )
 
         assert statement in claims["claims"]
@@ -107,7 +107,7 @@ class TestClaims:
         photo["owner"]["id"] = "-1"
 
         claims = create_sdc_claims_for_new_flickr_photo(
-            photo, retrieved_at=datetime.datetime.now()
+            photo, retrieved_at=datetime.now(tz=timezone.utc)
         )
 
         assert statement not in claims["claims"]
@@ -126,7 +126,7 @@ class TestClaims:
         assert statement is None
 
         claims = create_sdc_claims_for_new_flickr_photo(
-            photo, retrieved_at=datetime.datetime.now()
+            photo, retrieved_at=datetime.now(tz=timezone.utc)
         )
 
         assert not any(

--- a/tests/structured_data/statements/test_date_taken_statement.py
+++ b/tests/structured_data/statements/test_date_taken_statement.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 from flickr_photos_api import TakenGranularity
 import pytest
@@ -12,20 +12,20 @@ from utils import get_statement_fixture
     [
         # Based on https://www.flickr.com/photos/184374196@N07/53069446440
         (
-            datetime.datetime(2023, 2, 20, 23, 32, 31),
+            datetime(2023, 2, 20, 23, 32, 31),
             "second",
             "date_taken_YYYY-MM-DD.json",
         ),
         # Based on https://www.flickr.com/photos/normko/361850789
-        (datetime.datetime(1970, 3, 1, 0, 0, 0), "month", "date_taken_YYYY-MM.json"),
+        (datetime(1970, 3, 1, 0, 0, 0), "month", "date_taken_YYYY-MM.json"),
         # Based on https://www.flickr.com/photos/nationalarchives/5240741057
-        (datetime.datetime(1950, 1, 1, 0, 0, 0), "year", "date_taken_YYYY.json"),
+        (datetime(1950, 1, 1, 0, 0, 0), "year", "date_taken_YYYY.json"),
         # Based on https://www.flickr.com/photos/nlireland/6975991819
-        (datetime.datetime(1910, 1, 1, 0, 0, 0), "circa", "date_taken_circa.json"),
+        (datetime(1910, 1, 1, 0, 0, 0), "circa", "date_taken_circa.json"),
     ],
 )
 def test_create_date_taken_statement(
-    date_taken: datetime.datetime, granularity: TakenGranularity, filename: str
+    date_taken: datetime, granularity: TakenGranularity, filename: str
 ) -> None:
     actual = create_date_taken_statement(
         date_taken={"value": date_taken, "granularity": granularity}
@@ -39,7 +39,7 @@ def test_create_date_taken_statement_fails_on_unrecognised_granularity() -> None
     with pytest.raises(ValueError, match="Unrecognised taken_granularity"):
         create_date_taken_statement(
             date_taken={
-                "value": datetime.datetime.now(),
+                "value": datetime.now(tz=timezone.utc),
                 "granularity": -1,  # type: ignore
                 "unknown": False,
             }

--- a/tests/structured_data/statements/test_published_in_statement.py
+++ b/tests/structured_data/statements/test_published_in_statement.py
@@ -1,11 +1,11 @@
-import datetime
+from datetime import datetime
 
 from flickypedia.structured_data.statements import create_published_in_statement
 from utils import get_statement_fixture
 
 
 def test_create_published_in_statement() -> None:
-    actual = create_published_in_statement(date_posted=datetime.datetime(2023, 10, 12))
+    actual = create_published_in_statement(date_posted=datetime(2023, 10, 12))
     expected = get_statement_fixture(filename="date_posted_to_flickr.json")
 
     assert actual == expected

--- a/tests/structured_data/statements/test_source_statement.py
+++ b/tests/structured_data/statements/test_source_statement.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from flickypedia.structured_data.statements import create_source_statement
 from utils import get_statement_fixture
@@ -9,7 +9,7 @@ def test_create_source_statement() -> None:
         photo_id="53248015596",
         photo_url="https://www.flickr.com/photos/199246608@N02/53248015596/",
         original_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",
-        retrieved_at=datetime.datetime(2023, 11, 14, 16, 15, 0),
+        retrieved_at=datetime(2023, 11, 14, 16, 15, 0),
     )
     expected = get_statement_fixture(filename="photo_source_data.json")
 

--- a/tests/structured_data/test_claims.py
+++ b/tests/structured_data/test_claims.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 from flickr_photos_api import FlickrApi, SinglePhoto
 
@@ -38,7 +38,7 @@ def test_create_sdc_claims_for_flickr_photo_without_date_taken() -> None:
             "label": "CC BY 2.0",
             "url": "https://creativecommons.org/licenses/by/2.0/",
         },
-        "date_posted": datetime.datetime.fromtimestamp(1696939706),
+        "date_posted": datetime.fromtimestamp(1696939706),
         "date_taken": None,
         "safety_level": "safe",
         "original_format": "jpg",
@@ -54,7 +54,7 @@ def test_create_sdc_claims_for_flickr_photo_without_date_taken() -> None:
     }
 
     actual = create_sdc_claims_for_new_flickr_photo(
-        photo=photo, retrieved_at=datetime.datetime(2023, 11, 14, 16, 15, 0)
+        photo=photo, retrieved_at=datetime(2023, 11, 14, 16, 15, 0)
     )
     expected = get_claims_fixture("photo_53248015596.json")
 
@@ -89,9 +89,9 @@ def test_create_sdc_claims_for_flickr_photo_with_date_taken() -> None:
             "label": "CC BY 2.0",
             "url": "https://creativecommons.org/licenses/by/2.0/",
         },
-        "date_posted": datetime.datetime.fromtimestamp(1696421915),
+        "date_posted": datetime.fromtimestamp(1696421915),
         "date_taken": {
-            "value": datetime.datetime(2023, 10, 3, 5, 45, 0),
+            "value": datetime(2023, 10, 3, 5, 45, 0),
             "granularity": "second",
         },
         "safety_level": "safe",
@@ -108,7 +108,7 @@ def test_create_sdc_claims_for_flickr_photo_with_date_taken() -> None:
     }
 
     actual = create_sdc_claims_for_new_flickr_photo(
-        photo=photo, retrieved_at=datetime.datetime(2023, 11, 14, 16, 15, 0)
+        photo=photo, retrieved_at=datetime(2023, 11, 14, 16, 15, 0)
     )
     expected = get_claims_fixture("photo_53234140350.json")
 
@@ -143,9 +143,9 @@ def test_creates_sdc_for_photo_with_in_copyright_license() -> None:
             "label": "All Rights Reserved",
             "url": None,
         },
-        "date_posted": datetime.datetime.fromtimestamp(1414001923),
+        "date_posted": datetime.fromtimestamp(1414001923),
         "date_taken": {
-            "value": datetime.datetime(2014, 7, 14, 7, 56, 51),
+            "value": datetime(2014, 7, 14, 7, 56, 51),
             "granularity": "second",
         },
         "safety_level": "safe",
@@ -171,7 +171,7 @@ def test_omits_url_for_existing_photo(flickr_api: FlickrApi) -> None:
     photo = flickr_api.get_single_photo(photo_id="383861611")
 
     new_sdc = create_sdc_claims_for_new_flickr_photo(
-        photo, retrieved_at=datetime.datetime.now()
+        photo, retrieved_at=datetime.now(tz=timezone.utc)
     )
     existing_sdc = create_sdc_claims_for_existing_flickr_photo(photo)
 

--- a/tests/structured_data/types/test_wikidata_values.py
+++ b/tests/structured_data/types/test_wikidata_values.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import typing
 
 import pytest
@@ -8,7 +8,7 @@ from flickypedia.structured_data.types import DataValueTypes, to_wikidata_date_v
 
 ToWikidateArgs = typing.TypedDict(
     "ToWikidateArgs",
-    {"d": datetime.datetime, "precision": typing.Literal["day", "month", "year"]},
+    {"d": datetime, "precision": typing.Literal["day", "month", "year"]},
 )
 
 
@@ -16,7 +16,7 @@ ToWikidateArgs = typing.TypedDict(
     ["kwargs", "expected"],
     [
         (
-            {"d": datetime.datetime(2023, 10, 12, 1, 2, 3), "precision": "day"},
+            {"d": datetime(2023, 10, 12, 1, 2, 3), "precision": "day"},
             {
                 "value": {
                     "time": "+2023-10-12T00:00:00Z",
@@ -30,7 +30,7 @@ ToWikidateArgs = typing.TypedDict(
             },
         ),
         (
-            {"d": datetime.datetime(2023, 10, 12, 1, 2, 3), "precision": "month"},
+            {"d": datetime(2023, 10, 12, 1, 2, 3), "precision": "month"},
             {
                 "value": {
                     "time": "+2023-10-00T00:00:00Z",
@@ -44,7 +44,7 @@ ToWikidateArgs = typing.TypedDict(
             },
         ),
         (
-            {"d": datetime.datetime(2023, 10, 12, 1, 2, 3), "precision": "year"},
+            {"d": datetime(2023, 10, 12, 1, 2, 3), "precision": "year"},
             {
                 "value": {
                     "time": "+2023-00-00T00:00:00Z",

--- a/tests/uploadr/templates/prepare_info/test_structured_data_preview.py
+++ b/tests/uploadr/templates/prepare_info/test_structured_data_preview.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import re
 import typing
 
@@ -137,7 +137,7 @@ def test_shows_source_data(app: Flask, vcr_cassette: str) -> None:
         photo_id="53248015596",
         photo_url="https://www.flickr.com/photos/199246608@N02/53248015596/",
         original_url="https://live.staticflickr.com/65535/53248015596_c03f8123cf_o_d.jpg",
-        retrieved_at=datetime.datetime(2023, 11, 14, 16, 14, 0),
+        retrieved_at=datetime(2023, 11, 14, 16, 14, 0),
     )
 
     actual = get_html(claims=[source_claim])
@@ -191,7 +191,7 @@ def test_shows_license_statement(app: Flask, vcr_cassette: str) -> None:
 
 def test_shows_posted_statement(app: Flask, vcr_cassette: str) -> None:
     posted_date_claim = create_published_in_statement(
-        date_posted=datetime.datetime(2023, 10, 12)
+        date_posted=datetime(2023, 10, 12)
     )
 
     actual = get_html(claims=[posted_date_claim])
@@ -267,7 +267,7 @@ def test_shows_location_statement(
     [
         pytest.param(
             {
-                "value": datetime.datetime(2023, 10, 12),
+                "value": datetime(2023, 10, 12),
                 "granularity": "second",
                 "unknown": False,
             },
@@ -276,7 +276,7 @@ def test_shows_location_statement(
         ),
         pytest.param(
             {
-                "value": datetime.datetime(2023, 10, 1),
+                "value": datetime(2023, 10, 1),
                 "granularity": "second",
                 "unknown": False,
             },
@@ -285,7 +285,7 @@ def test_shows_location_statement(
         ),
         pytest.param(
             {
-                "value": datetime.datetime(2023, 10, 12),
+                "value": datetime(2023, 10, 12),
                 "granularity": "month",
                 "unknown": False,
             },
@@ -294,7 +294,7 @@ def test_shows_location_statement(
         ),
         pytest.param(
             {
-                "value": datetime.datetime(2023, 10, 12),
+                "value": datetime(2023, 10, 12),
                 "granularity": "year",
                 "unknown": False,
             },
@@ -303,7 +303,7 @@ def test_shows_location_statement(
         ),
         pytest.param(
             {
-                "value": datetime.datetime(2023, 10, 12),
+                "value": datetime(2023, 10, 12),
                 "granularity": "circa",
                 "unknown": False,
             },

--- a/tests/uploadr/test_auth.py
+++ b/tests/uploadr/test_auth.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 import json
 import os
 
@@ -60,7 +60,7 @@ def store_user(token: OAuth2Token | None = None) -> WikimediaUserSession:
         userid="-4",
         name="FlickypediaTestingUser",
         encrypted_token=encrypt_string(key, plaintext=json.dumps(oauth2_token)),
-        first_login=datetime.datetime.now(),
+        first_login=datetime.now(tz=timezone.utc),
     )
     user_db.session.add(user)
     user_db.session.commit()
@@ -231,7 +231,7 @@ def test_token_is_saved_to_database_when_refreshed(
 
         # Modify the 'expires_at' time, so it's actually 1 second ago -- as far
         # as authlib is concerned, this token is now invalid.
-        token["expires_at"] = int(datetime.datetime.now().timestamp() - 1)
+        token["expires_at"] = int(datetime.now(tz=timezone.utc).timestamp() - 1)
 
         # Now save a user with this token to the database.
         user = store_user(token=token)
@@ -245,7 +245,7 @@ def test_token_is_saved_to_database_when_refreshed(
 
         # Check that the user's token no longer matches the one we saved earlier.
         assert user.token() != token
-        assert user.token()["expires_at"] > datetime.datetime.now().timestamp()  # type: ignore
+        assert user.token()["expires_at"] > datetime.now(tz=timezone.utc).timestamp()  # type: ignore
 
         refreshed_token = user.token()
 
@@ -291,7 +291,7 @@ class TestLoadUser:
                 "expires_in": 14400,
                 "access_token": "[ACCESS_TOKEN...sqfLY]",
                 "refresh_token": "[REFRESH_TOKEN...8f34f]",
-                "expires_at": datetime.datetime.now().timestamp() + 3600,
+                "expires_at": datetime.now(tz=timezone.utc).timestamp() + 3600,
             }
         )
 

--- a/tests/uploadr/test_auth_can_log_in_to_wikimedia.py
+++ b/tests/uploadr/test_auth_can_log_in_to_wikimedia.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 from flask.testing import FlaskClient
 from flask_login import current_user
@@ -71,7 +71,7 @@ def test_can_get_token_from_wikimedia(
 
     # Now futz with the token -- set it to have just expired.  This should
     # force the OAuth client to refresh the token on the next request.
-    token["expires_at"] = int(datetime.datetime.now().timestamp()) - 1
+    token["expires_at"] = int(datetime.now(tz=timezone.utc).timestamp()) - 1
 
     # Construct an instance of the Wikimedia OAuth API, and check the token
     # is refreshed.  Check also that it's been stored.

--- a/tests/uploadr/test_uploads.py
+++ b/tests/uploadr/test_uploads.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from flask import Flask
 from flickr_photos_api import SinglePhoto
@@ -40,9 +40,9 @@ def test_upload_single_photo(app: Flask, wikimedia_api: WikimediaApi) -> None:
         ],
         "title": None,
         "description": None,
-        "date_posted": datetime.datetime.fromtimestamp(1701532872),
+        "date_posted": datetime.fromtimestamp(1701532872),
         "date_taken": {
-            "value": datetime.datetime(2021, 9, 22, 18, 3, 10),
+            "value": datetime(2021, 9, 22, 18, 3, 10),
             "granularity": "second",
         },
         "safety_level": "safe",
@@ -63,7 +63,7 @@ def test_upload_single_photo(app: Flask, wikimedia_api: WikimediaApi) -> None:
         request={
             "photo": photo,
             "sdc": create_sdc_claims_for_new_flickr_photo(
-                photo, retrieved_at=datetime.datetime(2023, 12, 2, 16, 2, 0)
+                photo, retrieved_at=datetime(2023, 12, 2, 16, 2, 0)
             ),
             "title": "Floor decoration at St Giles In The Fields.jpg",
             "caption": {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 import json
 import pathlib
 import re
@@ -89,7 +89,7 @@ def store_user(
         userid="-3",
         name="FlickypediaTestingUser",
         encrypted_token=encrypt_string(key, plaintext=json.dumps(oauth2_token)),
-        first_login=datetime.datetime.now(),
+        first_login=datetime.now(tz=timezone.utc),
     )
     user_db.session.add(user)
     user_db.session.commit()


### PR DESCRIPTION
This makes Flickypedia consistent with all our other projects.